### PR TITLE
Observer can now be extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,4 @@ solving of bugs, etc.) from the following developers :
  * Koert Gaaikema (@koertgaaikema)
  * Matt Logan (@mattlogan)
  * Aran Arunakiri
+ * @rckrdstrgrd

--- a/jni/instruments/synthinstrument.cpp
+++ b/jni/instruments/synthinstrument.cpp
@@ -93,8 +93,8 @@ bool SynthInstrument::removeEvent( BaseAudioEvent* audioEvent, bool isLiveEvent 
     // when using JNI, we let SWIG invoke destructors when Java references are finalized
     // otherwise we delete and dispose the events directly from this instrument
 #ifndef USE_JNI
-    delete aEvent;
-    aEvent = 0;
+    delete audioEvent;
+    audioEvent = 0;
 #endif
     return removed;
 }

--- a/jni/instruments/synthinstrument.cpp
+++ b/jni/instruments/synthinstrument.cpp
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2013-2016 Igor Zinken - http://www.igorski.nl
+ * Copyright (c) 2013-2018 Igor Zinken - http://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jni/messaging/notifier.cpp
+++ b/jni/messaging/notifier.cpp
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Igor Zinken - http://www.igorski.nl
+ * Copyright (c) 2015-2018 Igor Zinken - http://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -45,9 +45,7 @@ namespace Notifier
                                                                           std::vector<Observer*>() ));
 
         it = _observerMap.find( aNotificationType );
-        std::vector<Observer*> observers = it->second;
-
-        observers.push_back( aObserver );
+        it->second.push_back( aObserver );
     }
 
     void unregisterObserver( int aNotificationType, Observer* aObserver )

--- a/jni/messaging/observer.h
+++ b/jni/messaging/observer.h
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Igor Zinken - http://www.igorski.nl
+ * Copyright (c) 2015-2018 Igor Zinken - http://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -29,8 +29,8 @@ class Observer
         Observer();
         ~Observer();
 
-        void handleNotification( int aNotificationType );
-        void handleNotification( int aNotificationType, int aValue );
+        virtual void handleNotification( int aNotificationType );
+        virtual void handleNotification( int aNotificationType, int aValue );
 };
 
 #endif


### PR DESCRIPTION
Ensuring Observer can be extended as an C++ class, also fixing some bugs by observation (punny). Both cases noted by @rckrdstrgrd