### PR TITLE
Restored audio engine mock for unit testing the core engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/jni/drivers/adapter.cpp
+++ b/jni/drivers/adapter.cpp
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Igor Zinken - http://www.igorski.nl
+ * Copyright (c) 2017-2018 Igor Zinken - http://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -22,6 +22,7 @@
  */
 #include "adapter.h"
 #include "../audioengine.h"
+#include <utilities/debug.h>
 
 #if DRIVER == 0
 OPENSL_STREAM* driver_openSL = NULL; // OpenSL
@@ -35,6 +36,8 @@ namespace DriverAdapter {
 
 #if DRIVER == 0
 
+        Debug::log( "DriverAdapter::initializing OpenSL driver");
+
         // OpenSL
         driver_openSL = android_OpenAudioDevice(
             AudioEngineProps::SAMPLE_RATE, AudioEngineProps::INPUT_CHANNELS,
@@ -43,6 +46,8 @@ namespace DriverAdapter {
         return ( driver_openSL != NULL );
 
 #elif DRIVER == 1
+
+        Debug::log( "DriverAdapter::initializing AAudio driver");
 
         // AAudio
         driver_aAudio = new AAudio_IO(

--- a/jni/drivers/adapter.h
+++ b/jni/drivers/adapter.h
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Igor Zinken - http://www.igorski.nl
+ * Copyright (c) 2017-2018 Igor Zinken - http://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jni/drivers/adapter.h
+++ b/jni/drivers/adapter.h
@@ -58,14 +58,23 @@ namespace DriverAdapter {
 
 #if DRIVER == 0
 
-// OpenSL (note if mocking was requested - unit testing - mock_opensl_io.h has been included)
+// OpenSL
 
+#ifdef MOCK_ENGINE
+// mocking requested, e.g. unit test mode
+#include "../tests/helpers/mock_opensl_io.h"
+
+#else
+// production build for OpenSL
 #include "opensl_io.h"
+
+#endif
+
 extern OPENSL_STREAM* driver_openSL;
 
 #elif DRIVER == 1
 
-// AAudio
+// production build for AAudio
 #include "aaudio_io.h"
 extern AAudio_IO* driver_aAudio;
 

--- a/jni/tests/audioengine_test.cpp
+++ b/jni/tests/audioengine_test.cpp
@@ -1,5 +1,5 @@
-#include "../audiobuffer.h"
 #include "../audioengine.h"
+#include "../audiobuffer.h"
 #include "../sequencer.h"
 #include "../sequencercontroller.h"
 #include "../events/baseaudioevent.h"
@@ -11,7 +11,12 @@ TEST( AudioEngine, Start )
 
     // prepare engine environment
     SequencerController* controller = new SequencerController();
-    controller->prepare( 240, 48000, 130.0f, 4, 4 ); // 130 BPM in 4/4 time at 48 kHz sample rate w/buffer size of 240 samples
+
+    // 240 BPM in 4/4 time
+    controller->prepare( 240, 4, 4 );
+
+    // mono output with 48 kHz sample rate and buffer size of 240 samples
+    AudioEngine::setup( 240, 48000, 1 );
 
     AudioEngine::engine_started = false;
 
@@ -36,7 +41,13 @@ TEST( AudioEngine, TempoUpdate )
     float newTempo = randomFloat( 120.0f, 300.0f );
 
     SequencerController* controller = new SequencerController();
-    controller->prepare( 240, 48000, oldTempo, 4, 4 );
+
+    // 240 BPM in 4/4 time
+    controller->prepare( 240, 4, 4 );
+
+    // mono output with 48 kHz sample rate and buffer size of 240 samples
+    AudioEngine::setup( 240, 48000, 1 );
+
     controller->setTempoNow( oldTempo, 4, 4 ); // ensure tempo is applied immediately
     controller->rewind();
 
@@ -101,7 +112,13 @@ TEST( AudioEngine, Output )
     // prepare engine environment
 
     SequencerController* controller = new SequencerController();
-    controller->prepare( 16, 48000, 130.0f, 4, 4 ); // 130 BPM in 4/4 time at 48 kHz sample rate w/buffer size of 16 samples
+
+    // 130 BPM in 4/4 time
+    controller->prepare( 1340, 4, 4 );
+
+    // mono output with 48 kHz sample rate and buffer size of 16 samples
+    AudioEngine::setup( 16, 48000, 1 );
+
     controller->setTempoNow( 130.0f, 4, 4 );
     controller->rewind();
 
@@ -176,7 +193,13 @@ TEST( AudioEngine, OutputAtLoopStart )
     // prepare engine environment
 
     SequencerController* controller = new SequencerController();
-    controller->prepare( 11025, 44100, 120.0f, 4, 4 ); // 44.1 kHz, 4/4 time at 120 BPM w/ buffer size of 11025 samples
+
+    // 1240 BPM in 4/4 time
+    controller->prepare( 120, 4, 4 );
+
+    // mono output with 44.1 kHz sample rate and buffer size of 11025 samples
+    AudioEngine::setup( 11025, 44100, 1 );
+
     controller->setTempoNow( 120.0f, 4, 4 );
     controller->rewind();
 

--- a/jni/tests/events/baseaudioevent_test.cpp
+++ b/jni/tests/events/baseaudioevent_test.cpp
@@ -404,9 +404,17 @@ TEST( BaseAudioEvent, PositionInSeconds )
     float expectedEndPosition = startPosition + expectedDuration;
     audioEvent->setDuration( expectedDuration );
 
-    EXPECT_FLOAT_EQ( expectedDuration, audioEvent->getDuration() );
-    EXPECT_FLOAT_EQ( expectedEndPosition, audioEvent->getEndPosition())
-        << "expected end position to have corrected after updating of duration";
+    // there may be a tiny loss in floating point precision so we round the resolution
+
+    EXPECT_FLOAT_EQ(
+        floatRounding( expectedDuration, 5 ),
+        floatRounding( audioEvent->getDuration(), 5 )
+    );
+
+    EXPECT_FLOAT_EQ(
+        floatRounding( expectedEndPosition, 5 ),
+        floatRounding( audioEvent->getEndPosition(), 5 )
+    ) << "expected end position to have corrected after updating of duration";
 
     deleteAudioEvent( audioEvent );
 }

--- a/jni/tests/helpers/helper.cpp
+++ b/jni/tests/helpers/helper.cpp
@@ -46,6 +46,24 @@ float randomFloat( float min, float max )
     return ( min + f * ( max - min ));
 }
 
+// round the precision of a floating point value
+// e.g. src of 7.1234 with precision of 2 becomes 7.12
+
+float floatRounding( float src, int precision ) {
+    long long des;
+    double tmp;
+    tmp = ( double ) src * pow( 10, precision );
+
+    if ( tmp < 0 ) {
+        //negative double
+        des = ( long long ) (tmp - 0.5 );
+    }
+    else {
+        des = ( long long )( tmp + 0.5 );
+    }
+    return ( float )(( float ) des * pow( 10, -precision ));
+}
+
 // return a random sample value between given min - max range
 
 SAMPLE_TYPE randomSample( double min, double max )

--- a/jni/tests/helpers/mock_opensl_io.cpp
+++ b/jni/tests/helpers/mock_opensl_io.cpp
@@ -1,9 +1,9 @@
 #include "mock_opensl_io.h"
+#include "../../audioengine.h"
+#include "../../sequencer.h"
 #include "../../utilities/debug.h"
 
-int lastIteration = -1;
-
-OPENSL_STREAM* mock_android_OpenAudioDevice( int sr, int inchannels, int outchannels, int bufferframes )
+inline OPENSL_STREAM* mock_android_OpenAudioDevice( int sr, int inchannels, int outchannels, int bufferframes )
 {
     Debug::log( "mocked device opening" );
 
@@ -18,7 +18,7 @@ OPENSL_STREAM* mock_android_OpenAudioDevice( int sr, int inchannels, int outchan
     return p;
 }
 
-void mock_android_CloseAudioDevice( OPENSL_STREAM *p )
+inline void mock_android_CloseAudioDevice( OPENSL_STREAM *p )
 {
     Debug::log( "mocked device closing" );
 
@@ -26,14 +26,14 @@ void mock_android_CloseAudioDevice( OPENSL_STREAM *p )
         free( p );
 }
 
-int mock_android_AudioIn( OPENSL_STREAM *p, float *buffer, int size )
+inline int mock_android_AudioIn( OPENSL_STREAM *p, float *buffer, int size )
 {
     AudioEngine::mock_opensl_time += ( float ) size / ( p->sr * p->inchannels );
 
     return size;
 }
 
-int mock_android_AudioOut( OPENSL_STREAM *p, float *buffer, int size )
+inline int mock_android_AudioOut( OPENSL_STREAM *p, float *buffer, int size )
 {
     // AudioEngine thread will halt all unit test execution
     // android_AudioOut is called upon each iteration, here
@@ -101,7 +101,6 @@ int mock_android_AudioOut( OPENSL_STREAM *p, float *buffer, int size )
                     ++AudioEngine::test_program;    // advance to next test
                     AudioEngine::stop();
                 }
-                lastIteration = currentIteration;
             }
             break;
 
@@ -144,7 +143,7 @@ int mock_android_AudioOut( OPENSL_STREAM *p, float *buffer, int size )
     return size;
 }
 
-float mock_android_GetTimestamp( OPENSL_STREAM *p )
+inline float mock_android_GetTimestamp( OPENSL_STREAM *p )
 {
     return AudioEngine::mock_opensl_time;
 }

--- a/jni/tests/main.cpp
+++ b/jni/tests/main.cpp
@@ -5,10 +5,9 @@
 #include <cstdlib>
 #include "helpers/helper.cpp"
 
+#include "audioengine_test.cpp"
 #include "audiobuffer_test.cpp"
 #include "audiochannel_test.cpp"
-// audioengine_test.cpp has trouble with new DriverAdapter...
-//#include "audioengine_test.cpp"
 #include "processingchain_test.cpp"
 #include "ringbuffer_test.cpp"
 #include "sequencer_test.cpp"


### PR DESCRIPTION
Testing of the AudioEngine core had been disabled after introduction of the audio driver adapter. Verify whether tests pass and both OpenSL and AAudio production builds still work as expected.