### PR TITLE
Removed rudimentary MAX_PHASE definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ packaging directly both from its IDE.
 
 When NDK builds fail, be aware that _ndk-build_ doesn't like it when paths contain spaces (yeah...)
 
+In case the Java build fails due to missing classes, see below to compile the
+audio engine as a library using CLI.
+
 #### Using CLI
 
 After making sure you have all the correct tools (see _Environment setup_):

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# custom to your machine : Android NDK library location
+export ANDROID_NDK_ROOT=/Library/AndroidNDK
+
+# the input folders for the C++ sources
+export NDK_PROJECT_PATH=./src/main/cpp
+INPUT="-I./src/main/cpp"
+
+# flush output folders
+rm -rf libs
+rm -rf src/main/java/nl/igorski/lib/audio/mwengine
+
+# explicitly provide paths to .mk files as default ndk-build expects files in a folder called ./jni
+$ANDROID_NDK_ROOT/ndk-build clean -C $NDK_PROJECT_PATH APP_BUILD_SCRIPT=Android.mk NDK_APPLICATION_MK=Application.mk NDK_LIBS_OUT=../../../libs V=1 $1

--- a/src/main/cpp/audiochannel.cpp
+++ b/src/main/cpp/audiochannel.cpp
@@ -82,7 +82,7 @@ void AudioChannel::readCachedBuffer( AudioBuffer* aOutputBuffer, int aReadOffset
 {
     if ( aReadOffset >= _cacheStartOffset && aReadOffset <= _cacheEndOffset )
     {
-        aOutputBuffer->mergeBuffers( _cachedBuffer, _cacheReadPointer, 0, MAX_PHASE );
+        aOutputBuffer->mergeBuffers( _cachedBuffer, _cacheReadPointer, 0, 1.0 );
         _cacheReadPointer += aOutputBuffer->bufferSize;
     }
 }
@@ -178,7 +178,7 @@ void AudioChannel::mixBuffer( AudioBuffer* bufferToMixInto, float mixVolume ) {
  */
 void AudioChannel::writeCache( AudioBuffer* aBuffer, int aReadOffset )
 {
-    int mergedSamples   = _cachedBuffer->mergeBuffers( aBuffer, aReadOffset, _cacheWritePointer, MAX_PHASE );
+    int mergedSamples   = _cachedBuffer->mergeBuffers( aBuffer, aReadOffset, _cacheWritePointer, 1.0 );
     _cacheWritePointer += mergedSamples;
 
     // caching completed ?
@@ -238,7 +238,7 @@ void AudioChannel::init()
     _cacheWritePointer = 0;
     _cacheStartOffset  = 0;
     _cacheEndOffset    = 0;
-    _volume            = VolumeUtil::toLog( MAX_PHASE );
+    _volume            = VolumeUtil::toLog( 1.0 );
     maxBufferPosition  = 0;
     processingChain    = new ProcessingChain();
 

--- a/src/main/cpp/audioengine.cpp
+++ b/src/main/cpp/audioengine.cpp
@@ -93,7 +93,7 @@ namespace AudioEngine
 
     /* output related */
 
-    float volume = MAX_PHASE;
+    float volume = 1.0;
     ProcessingChain* masterBus = new ProcessingChain();
 
     static int thread;
@@ -312,7 +312,7 @@ namespace AudioEngine
                 // is played on the same instrument, but just as a different voice (note the
                 // events can have their own mix level)
 
-                float lAmp = channelVolume > 0.f ? MAX_PHASE / channelVolume : MAX_PHASE;
+                float lAmp = channelVolume > 0.f ? 1.0 / channelVolume : 1.0;
 
                 for ( int k = 0; k < lAmount; ++k )
                 {
@@ -349,7 +349,7 @@ namespace AudioEngine
             // write the channel buffer into the combined output buffer, apply channel volume
             // note live events are always audible as their volume is relative to the instrument
             if ( channel->hasLiveEvents && channelVolume == 0.0 )
-                channelVolume = MAX_PHASE;
+                channelVolume = 1.0;
 
             channel->mixBuffer( inBuffer, channelVolume );
         }
@@ -370,11 +370,11 @@ namespace AudioEngine
 
                 // and perform a fail-safe check in case we're exceeding the headroom ceiling
 
-                if ( sample < -MAX_PHASE )
-                    sample = -MAX_PHASE;
+                if ( sample < -1.0 )
+                    sample = -1.0;
 
-                else if ( sample > +MAX_PHASE )
-                    sample = +MAX_PHASE;
+                else if ( sample > +1.0 )
+                    sample = +1.0;
 
                 // write output interleaved (e.g. a sample per output channel
                 // before continuing writing the next sample for the next channel range)

--- a/src/main/cpp/events/baseaudioevent.cpp
+++ b/src/main/cpp/events/baseaudioevent.cpp
@@ -510,7 +510,7 @@ void BaseAudioEvent::construct()
     _loopeable         = false;
     _locked            = false;
     _addedToSequencer  = false;
-    _volume            = VolumeUtil::toLog( MAX_PHASE );
+    _volume            = VolumeUtil::toLog( 1.0 );
     _eventStart        = 0;
     _eventEnd          = 0;
     _eventLength       = 0;

--- a/src/main/cpp/events/basesynthevent.cpp
+++ b/src/main/cpp/events/basesynthevent.cpp
@@ -80,7 +80,7 @@ void BaseSynthEvent::play()
 
     lastWriteIndex             = 0;
     cachedProps.envelopeOffset = 0;
-    cachedProps.envelope       = ( _synthInstrument->adsr->getAttackTime() > 0 ) ? 0.0 : MAX_PHASE;
+    cachedProps.envelope       = ( _synthInstrument->adsr->getAttackTime() > 0 ) ? 0.0 : 1.0;
 
     BaseAudioEvent::play();
 }
@@ -256,8 +256,8 @@ void BaseSynthEvent::mixBuffer( AudioBuffer* outputBuffer, int bufferPos,
         // render the snippet
         _synthInstrument->synthesizer->render( _buffer, this );
 
-        // note we merge using MAX_PHASE as mix volume (event volume was applied during synthesis)
-        outputBuffer->mergeBuffers( _buffer, 0, writeOffset, MAX_PHASE );
+        // note we merge using 1.0 as mix volume (event volume was applied during synthesis)
+        outputBuffer->mergeBuffers( _buffer, 0, writeOffset, 1.0 );
 
         // reset of event properties at end of write
         if ( lastWriteIndex >= _eventLength )
@@ -276,8 +276,8 @@ void BaseSynthEvent::mixBuffer( AudioBuffer* outputBuffer, int bufferPos,
 
             _synthInstrument->synthesizer->render( _buffer, this );    // overwrites old buffer contents
 
-            // note we merge using MAX_PHASE as mix volume (event volume was applied during synthesis)
-            outputBuffer->mergeBuffers( _buffer, 0, loopOffset, MAX_PHASE );
+            // note we merge using 1.0 as mix volume (event volume was applied during synthesis)
+            outputBuffer->mergeBuffers( _buffer, 0, loopOffset, 1.0 );
 
             // reset of event properties at end of write
             if ( lastWriteIndex >= _eventLength )
@@ -325,8 +325,8 @@ AudioBuffer* BaseSynthEvent::synthesize( int aBufferLength )
             {
                 int amt = ceil( aBufferLength / 4 );
 
-                SAMPLE_TYPE envIncr = MAX_PHASE / amt;
-                SAMPLE_TYPE amp     = MAX_PHASE;
+                SAMPLE_TYPE envIncr = 1.0 / amt;
+                SAMPLE_TYPE amp     = 1.0;
 
                 for ( int i = aBufferLength - amt; i < aBufferLength; ++i )
                 {
@@ -353,7 +353,7 @@ AudioBuffer* BaseSynthEvent::synthesize( int aBufferLength )
 void BaseSynthEvent::updateProperties()
 {
     // sync ADSR envelope values
-    cachedProps.envelope     = ( _synthInstrument->adsr->getAttackTime() > 0 ) ? 0.0 : MAX_PHASE;
+    cachedProps.envelope     = ( _synthInstrument->adsr->getAttackTime() > 0 ) ? 0.0 : 1.0;
     cachedProps.releaseLevel = ( SAMPLE_TYPE ) _synthInstrument->adsr->getSustainLevel();
 
     calculateBuffers();

--- a/src/main/cpp/generators/envelopegenerator.cpp
+++ b/src/main/cpp/generators/envelopegenerator.cpp
@@ -39,7 +39,7 @@ namespace EnvelopeGenerator
         startAmplitude = std::max(( SAMPLE_TYPE ) 0.001, startAmplitude );
         endAmplitude   = std::max(( SAMPLE_TYPE ) 0.001, endAmplitude );
 
-        SAMPLE_TYPE coeff  = MAX_PHASE + ( log( endAmplitude ) - log( startAmplitude )) / tableLength;
+        SAMPLE_TYPE coeff  = 1.0 + ( log( endAmplitude ) - log( startAmplitude )) / tableLength;
         SAMPLE_TYPE sample = startAmplitude;
 
         for ( int i = 0; i < tableLength; ++i )

--- a/src/main/cpp/generators/envelopegenerator.h
+++ b/src/main/cpp/generators/envelopegenerator.h
@@ -34,8 +34,8 @@ namespace EnvelopeGenerator
     // tableLength describes the size of the table
     // startAmplitude describes the amplitude level at the beginning of the envelope where
     // endAmplitude describes the amplitude level at the end of the envelope, e.g.
-    // a startAmplitude of MAX_PHASE and an endAmplitude of 0.0 would create a fade out-envelope
-    // and a startAmplitude of 0.0 and an endAmplitude of MAX_PHASE would create a fade in-envelope
+    // a startAmplitude of 1.0 and an endAmplitude of 0.0 would create a fade out-envelope
+    // and a startAmplitude of 0.0 and an endAmplitude of 1.0 would create a fade in-envelope
 
     extern SAMPLE_TYPE* generateLinear( int tableLength, SAMPLE_TYPE startAmplitude, SAMPLE_TYPE endAmplitude );
 

--- a/src/main/cpp/generators/synthesizer.cpp
+++ b/src/main/cpp/generators/synthesizer.cpp
@@ -259,9 +259,9 @@ void Synthesizer::render( AudioBuffer* aOutputBuffer, BaseSynthEvent* aEvent )
         {
             phase += aEvent->cachedProps.phaseIncr;
 
-            // keep phase within range (-MAX_PHASE to +MAX_PHASE)
-            if ( phase > MAX_PHASE )
-                phase -= MAX_PHASE;
+            // keep phase within range (-1.0 to +1.0)
+            if ( phase > 1.0 )
+                phase -= 1.0;
         }
 
         // update modules

--- a/src/main/cpp/generators/synthesizer.cpp
+++ b/src/main/cpp/generators/synthesizer.cpp
@@ -259,7 +259,7 @@ void Synthesizer::render( AudioBuffer* aOutputBuffer, BaseSynthEvent* aEvent )
         {
             phase += aEvent->cachedProps.phaseIncr;
 
-            // keep phase within range (-1.0 to +1.0)
+            // keep phase within range
             if ( phase > 1.0 )
                 phase -= 1.0;
         }

--- a/src/main/cpp/generators/wavegenerator.cpp
+++ b/src/main/cpp/generators/wavegenerator.cpp
@@ -69,7 +69,7 @@ namespace WaveGenerator
 
                         case WaveForms::TRIANGLE:
                             sample += sin(( SAMPLE_TYPE ) s * TWO_PI * ( SAMPLE_TYPE ) t / numberOfSamples );
-                            tmp     = 1.0 - ( SAMPLE_TYPE ) ( std::abs( sample - ( 1.0 / 2 ) )) * ( 1.0 * 4.0 );
+                            tmp     = 1.0 - ( SAMPLE_TYPE ) ( std::abs( sample - 0.5 )) * 4.0;
                             break;
 
                         case WaveForms::SAWTOOTH:

--- a/src/main/cpp/generators/wavegenerator.cpp
+++ b/src/main/cpp/generators/wavegenerator.cpp
@@ -69,7 +69,7 @@ namespace WaveGenerator
 
                         case WaveForms::TRIANGLE:
                             sample += sin(( SAMPLE_TYPE ) s * TWO_PI * ( SAMPLE_TYPE ) t / numberOfSamples );
-                            tmp     = MAX_PHASE - ( SAMPLE_TYPE ) ( std::abs( sample - ( MAX_PHASE / 2 ) )) * ( MAX_PHASE * 4.0 );
+                            tmp     = 1.0 - ( SAMPLE_TYPE ) ( std::abs( sample - ( 1.0 / 2 ) )) * ( 1.0 * 4.0 );
                             break;
 
                         case WaveForms::SAWTOOTH:
@@ -79,7 +79,7 @@ namespace WaveGenerator
 
                         case WaveForms::SQUARE:
                             sample += sin(( SAMPLE_TYPE ) s * TWO_PI * ( SAMPLE_TYPE ) t / numberOfSamples );
-                            tmp     = ( sample >= 0.0 ) ? MAX_PHASE : -MAX_PHASE;
+                            tmp     = ( sample >= 0.0 ) ? 1.0 : -1.0;
                             break;
                     }
                 }
@@ -88,7 +88,7 @@ namespace WaveGenerator
                 if ( tmp > maxValue )
                     maxValue = tmp;
             }
-            SAMPLE_TYPE factor = MAX_PHASE / maxValue;
+            SAMPLE_TYPE factor = 1.0 / maxValue;
 
             // normalize values
             for ( int j = 0; j < numberOfSamples; ++j )

--- a/src/main/cpp/global.h
+++ b/src/main/cpp/global.h
@@ -63,9 +63,9 @@ namespace AudioEngineProps
     extern int OUTPUT_CHANNELS; // initialized on engine start, valid options are 1 (mono) and 2 (stereo)
 
 #ifdef RECORD_DEVICE_INPUT
-    const int INPUT_CHANNELS   = 1;
+    const int INPUT_CHANNELS = 1;
 #else
-    const int INPUT_CHANNELS   = 0;
+    const int INPUT_CHANNELS = 0;
 #endif
 }
 
@@ -73,12 +73,10 @@ namespace AudioEngineProps
 
 #if PRECISION == 1 // float
  #define SAMPLE_TYPE float
- #define MAX_PHASE 1.0f
 #endif
 
 #if PRECISION == 2 // double
  #define SAMPLE_TYPE double
- #define MAX_PHASE 1.0
 #endif
 
 // global constants used throughout the engine

--- a/src/main/cpp/instruments/baseinstrument.cpp
+++ b/src/main/cpp/instruments/baseinstrument.cpp
@@ -163,7 +163,7 @@ void BaseInstrument::unregisterFromSequencer()
 
 void BaseInstrument::construct()
 {
-    audioChannel = new AudioChannel( MAX_PHASE );
+    audioChannel = new AudioChannel( 1.0 );
 
     // events
 

--- a/src/main/cpp/instruments/druminstrument.cpp
+++ b/src/main/cpp/instruments/druminstrument.cpp
@@ -143,7 +143,7 @@ void DrumInstrument::construct()
 {
     drumTimbre        = DrumTimbres::LIGHT;
     rOsc              = 0;// new RouteableOscillator();  // currently unused...
-    audioChannel      = new AudioChannel( MAX_PHASE, AudioEngine::samples_per_bar );
+    audioChannel      = new AudioChannel( 1.0, AudioEngine::samples_per_bar );
 
     activeDrumPattern = 0;
     drumPatterns      = new std::vector<DrumPattern*>();

--- a/src/main/cpp/instruments/synthinstrument.cpp
+++ b/src/main/cpp/instruments/synthinstrument.cpp
@@ -112,7 +112,7 @@ void SynthInstrument::init()
 
     adsr->setAttackTime  ( 0.01 );
     adsr->setDecayTime   ( 0.0 );
-    adsr->setSustainLevel( MAX_PHASE );
+    adsr->setSustainLevel( 1.0 );
     adsr->setReleaseTime ( 0.01 );
 
     // default values

--- a/src/main/cpp/processors/dcoffsetfilter.cpp
+++ b/src/main/cpp/processors/dcoffsetfilter.cpp
@@ -38,7 +38,7 @@ DCOffsetFilter::DCOffsetFilter( int amountOfChannels )
         _lastOutSamples[ i ] = 0.0;
     }
     SAMPLE_TYPE baseFrequency = 65.41; // is a C2 note
-    R = MAX_PHASE - ( TWO_PI * baseFrequency / AudioEngineProps::SAMPLE_RATE );
+    R = 1.0 - ( TWO_PI * baseFrequency / AudioEngineProps::SAMPLE_RATE );
 }
 
 DCOffsetFilter::~DCOffsetFilter()

--- a/src/main/cpp/processors/limiter.cpp
+++ b/src/main/cpp/processors/limiter.cpp
@@ -80,7 +80,7 @@ void Limiter::setThreshold( float thresholdDb )
 
 float Limiter::getLinearGR()
 {
-    return gain > 1.0 ? 1.0 / gain : 1.0;
+    return ( gain > 1.0f ) ? 1.0f / ( float ) gain : 1.0f;
 }
 
 void Limiter::process( AudioBuffer* sampleBuffer, bool isMonoSource )

--- a/src/main/cpp/processors/limiter.cpp
+++ b/src/main/cpp/processors/limiter.cpp
@@ -80,7 +80,7 @@ void Limiter::setThreshold( float thresholdDb )
 
 float Limiter::getLinearGR()
 {
-    return gain > MAX_PHASE ? MAX_PHASE / gain : MAX_PHASE;
+    return gain > 1.0 ? 1.0 / gain : 1.0;
 }
 
 void Limiter::process( AudioBuffer* sampleBuffer, bool isMonoSource )
@@ -169,7 +169,7 @@ void Limiter::init( float attackMs, float releaseMs, float thresholdDb )
     pTrim    = ( SAMPLE_TYPE ) 0.60;
     pKnee    = ( SAMPLE_TYPE ) 0.40;
 
-    gain = MAX_PHASE;
+    gain = 1.0;
 
     recalculate();
 }

--- a/src/main/cpp/processors/reverb.cpp
+++ b/src/main/cpp/processors/reverb.cpp
@@ -20,6 +20,7 @@
 #include "reverb.h"
 #include <algorithm>
 #include <cstring>
+#include <utilities/utils.h>
 
 /* constructor / destructor */
 
@@ -67,7 +68,7 @@ float Reverb::getSize()
 
 void Reverb::setSize( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
+    value = capParam( value );
 
     if ( _size != value ) {
         _size = value;
@@ -82,7 +83,7 @@ float Reverb::getHFDamp()
 
 void Reverb::setHFDamp( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
+    value = capParam( value );
 
     if ( _hfDamp != value ) {
         _hfDamp = value;
@@ -97,7 +98,7 @@ float Reverb::getMix()
 
 void Reverb::setMix( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
+    value = capParam( value );
 
     if ( _mix != value ) {
         _mix = value;
@@ -112,7 +113,7 @@ float Reverb::getOutput()
 
 void Reverb::setOutput( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
+    value = capParam( value );
 
     if ( _output != value ) {
         _output = value;

--- a/src/main/cpp/processors/reverb.cpp
+++ b/src/main/cpp/processors/reverb.cpp
@@ -67,7 +67,7 @@ float Reverb::getSize()
 
 void Reverb::setSize( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) MAX_PHASE ));
+    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
 
     if ( _size != value ) {
         _size = value;
@@ -82,7 +82,7 @@ float Reverb::getHFDamp()
 
 void Reverb::setHFDamp( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) MAX_PHASE ));
+    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
 
     if ( _hfDamp != value ) {
         _hfDamp = value;
@@ -97,7 +97,7 @@ float Reverb::getMix()
 
 void Reverb::setMix( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) MAX_PHASE ));
+    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
 
     if ( _mix != value ) {
         _mix = value;
@@ -112,7 +112,7 @@ float Reverb::getOutput()
 
 void Reverb::setOutput( float value )
 {
-    value = std::max( 0.f, std::min( value, ( float ) MAX_PHASE ));
+    value = std::max( 0.f, std::min( value, ( float ) 1.0 ));
 
     if ( _output != value ) {
         _output = value;

--- a/src/main/cpp/processors/tremolo.cpp
+++ b/src/main/cpp/processors/tremolo.cpp
@@ -37,12 +37,12 @@ Tremolo::Tremolo( int aLeftType,  int aLeftAttack,  int aLeftDecay,
     SAMPLE_TYPE* rightTable;
 
     if ( aLeftType == LINEAR )
-        leftTable = EnvelopeGenerator::generateLinear( ENVELOPE_PRECISION, 0.0, MAX_PHASE );
+        leftTable = EnvelopeGenerator::generateLinear( ENVELOPE_PRECISION, 0.0, 1.0 );
     else
         leftTable = EnvelopeGenerator::generateExponential( ENVELOPE_PRECISION );
 
     if ( aRightType == LINEAR )
-        rightTable = EnvelopeGenerator::generateLinear( ENVELOPE_PRECISION, 0.0, MAX_PHASE );
+        rightTable = EnvelopeGenerator::generateLinear( ENVELOPE_PRECISION, 0.0, 1.0 );
     else
         rightTable = EnvelopeGenerator::generateExponential( ENVELOPE_PRECISION );
 

--- a/src/main/cpp/processors/waveshaper.cpp
+++ b/src/main/cpp/processors/waveshaper.cpp
@@ -68,14 +68,14 @@ void WaveShaper::setAmount( float value )
     // keep within range
 
     if ( value <= -1.0 )
-        value = -( 1.0 - .1f );
+        value = -0.9f;
 
     else if ( value >= 1.0 )
-        value = 1.0 - .1f;
+        value = 0.9f;
 
     _amount = value;
 
-    _multiplier = ( 1.0 * 2.0 ) * _amount / ( 1.0 - _amount );
+    _multiplier = 2.0f * _amount / ( 1.0f - _amount );
 }
 
 float WaveShaper::getLevel()

--- a/src/main/cpp/processors/waveshaper.cpp
+++ b/src/main/cpp/processors/waveshaper.cpp
@@ -44,7 +44,7 @@ void WaveShaper::process( AudioBuffer* sampleBuffer, bool isMonoSource )
         for ( int j = 0; j < bufferSize; ++j )
         {
             SAMPLE_TYPE input = channelBuffer[ j ];
-            channelBuffer[ j ] = (( MAX_PHASE + _multiplier ) * input / ( MAX_PHASE + _multiplier * std::abs( input ))) * _level;
+            channelBuffer[ j ] = (( 1.0 + _multiplier ) * input / ( 1.0 + _multiplier * std::abs( input ))) * _level;
         }
 
         // omit unnecessary cycles by copying the mono content
@@ -67,15 +67,15 @@ void WaveShaper::setAmount( float value )
 {
     // keep within range
 
-    if ( value <= -MAX_PHASE )
-        value = -( MAX_PHASE - .1f );
+    if ( value <= -1.0 )
+        value = -( 1.0 - .1f );
 
-    else if ( value >= MAX_PHASE )
-        value = MAX_PHASE - .1f;
+    else if ( value >= 1.0 )
+        value = 1.0 - .1f;
 
     _amount = value;
 
-    _multiplier = ( MAX_PHASE * 2.0 ) * _amount / ( MAX_PHASE - _amount );
+    _multiplier = ( 1.0 * 2.0 ) * _amount / ( 1.0 - _amount );
 }
 
 float WaveShaper::getLevel()

--- a/src/main/cpp/tests/audiobuffer_test.cpp
+++ b/src/main/cpp/tests/audiobuffer_test.cpp
@@ -50,7 +50,7 @@ TEST( AudioBuffer, Silence )
 TEST( AudioBuffer, AdjustVolumes )
 {
     AudioBuffer* audioBuffer = fillAudioBuffer( randomAudioBuffer() );
-    SAMPLE_TYPE multiplier   = randomSample( 0.0, MAX_PHASE );
+    SAMPLE_TYPE multiplier   = randomSample( 0.0, 1.0 );
     SAMPLE_TYPE maxValue     = getMaxAmpForBuffer( audioBuffer );
 
     audioBuffer->adjustBufferVolumes( multiplier );
@@ -228,7 +228,7 @@ TEST( AudioBuffer, ApplyMonoSource )
         SAMPLE_TYPE* buffer = audioBuffer->getBufferForChannel( c );
 
         for ( int i = 0, l = audioBuffer->bufferSize; i < l; ++i )
-            buffer[ i ] = randomSample( -MAX_PHASE, +MAX_PHASE );
+            buffer[ i ] = randomSample( -1.0, +1.0 );
     }
 
     // get all mono values

--- a/src/main/cpp/tests/audiochannel_test.cpp
+++ b/src/main/cpp/tests/audiochannel_test.cpp
@@ -4,7 +4,7 @@
 
 TEST( AudioChannel, Construction )
 {
-    float volume = ( float ) randomSample( 0, MAX_PHASE );
+    float volume = ( float ) randomSample( 0, 1.0 );
     AudioChannel* audioChannel = new AudioChannel( volume );
 
     EXPECT_EQ( audioChannel->getVolume(), volume )
@@ -27,7 +27,7 @@ TEST( AudioChannel, Construction )
 
 TEST( AudioChannel, Volume )
 {
-    float volume    = ( float ) randomSample( 0, MAX_PHASE );
+    float volume    = ( float ) randomSample( 0, 1.0 );
     float logVolume = VolumeUtil::toLog( volume );
 
     AudioChannel* audioChannel = new AudioChannel( volume );
@@ -43,7 +43,7 @@ TEST( AudioChannel, Volume )
 
 TEST( AudioChannel, InstanceId )
 {
-    float volume = ( float ) randomSample( 0, MAX_PHASE );
+    float volume = ( float ) randomSample( 0, 1.0 );
 
     // 1. create first channel
 
@@ -75,7 +75,7 @@ TEST( AudioChannel, InstanceId )
 
 TEST( AudioChannel, Events )
 {
-    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, MAX_PHASE ));
+    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, 1.0 ));
 
     EXPECT_EQ( audioChannel->audioEvents.size(), 0 )
         << "expected AudioChannel events vector to be empty upon construction";
@@ -97,7 +97,7 @@ TEST( AudioChannel, Events )
 
 TEST( AudioChannel, LiveEvents )
 {
-    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, MAX_PHASE ));
+    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, 1.0 ));
 
     ASSERT_FALSE( audioChannel->hasLiveEvents )
         << "expected AudioChannel to contain no live events upon construction";
@@ -128,7 +128,7 @@ TEST( AudioChannel, LiveEvents )
 
 TEST( AudioChannel, OutputBuffer )
 {
-    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, MAX_PHASE ));
+    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, 1.0 ));
     AudioBuffer* outputBuffer  = audioChannel->getOutputBuffer();
 
     // ensure created buffer matches engine properties
@@ -167,7 +167,7 @@ TEST( AudioChannel, OutputBuffer )
 
 TEST( AudioChannel, Caching )
 {
-    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, MAX_PHASE ));
+    AudioChannel* audioChannel = new AudioChannel( ( float ) randomSample( 0, 1.0 ));
 
     ASSERT_FALSE( audioChannel->canCache() )
         << "expected caching to be disabled by default on construction";
@@ -289,7 +289,7 @@ TEST( AudioChannel, MixPannedBuffer )
 
     // TEST 1. right panning (source buffer has only left channel content, no right channel)
 
-    srcLeft[0] = MAX_PHASE;
+    srcLeft[0] = 1.0;
     srcRight[0] = 0.0f;
 
     audioChannel->setPan( 0.3 ); // set pan slightly to the right
@@ -303,7 +303,7 @@ TEST( AudioChannel, MixPannedBuffer )
     // TEST 2. left panning (source buffer has only right channel content, no left channel)
 
     srcLeft[0] = 0.0f;
-    srcRight[0] = MAX_PHASE;
+    srcRight[0] = 1.0;
 
     audioChannel->setPan( -0.7 ); // set pan slightly to the left
     audioChannel->mixBuffer( mixBuffer, 1 );

--- a/src/main/cpp/tests/audioengine_test.cpp
+++ b/src/main/cpp/tests/audioengine_test.cpp
@@ -138,13 +138,13 @@ TEST( AudioEngine, Output )
     SAMPLE_TYPE* rawBuffer = buffer->getBufferForChannel( 0 );
 
     for ( int i = 0; i < 4; ++i )
-        rawBuffer[ i ] = ( SAMPLE_TYPE ) -MAX_PHASE;
+        rawBuffer[ i ] = ( SAMPLE_TYPE ) -1.0;
 
     for ( int i = 4; i < 8; ++i )
         rawBuffer[ i ] = ( SAMPLE_TYPE ) 0;
 
     for ( int i = 8; i < 12; ++i )
-        rawBuffer[ i ] = ( SAMPLE_TYPE ) MAX_PHASE;
+        rawBuffer[ i ] = ( SAMPLE_TYPE ) 1.0;
 
     for ( int i = 12; i < 16; ++i )
         rawBuffer[ i ] = ( SAMPLE_TYPE ) 0;

--- a/src/main/cpp/tests/benchmarks/buffer_test.cpp
+++ b/src/main/cpp/tests/benchmarks/buffer_test.cpp
@@ -164,7 +164,7 @@ TEST( BufferBenchmark, LoopingVersusMemcpyCloning )
     int i, j;
 
     for ( i = 0; i < bufferSize; ++i ) {
-        sourceBuffer[ i ] = randomSample( -MAX_PHASE, MAX_PHASE );
+        sourceBuffer[ i ] = randomSample( -1.0, 1.0 );
     }
 
     // test 4. cloning buffer contents using looping versus memcpy

--- a/src/main/cpp/tests/benchmarks/inline_test.cpp
+++ b/src/main/cpp/tests/benchmarks/inline_test.cpp
@@ -53,7 +53,7 @@ TEST( RingBufferBenchmark, EnqueueBenchmark )
     int i, j;
 
     SAMPLE_TYPE value;
-    SAMPLE_TYPE sample = randomSample( -MAX_PHASE, MAX_PHASE );
+    SAMPLE_TYPE sample = randomSample( -1.0, 1.0 );
 
     test1start = getTime();
 

--- a/src/main/cpp/tests/benchmarks/table_test.cpp
+++ b/src/main/cpp/tests/benchmarks/table_test.cpp
@@ -54,9 +54,9 @@ TEST( TableBenchmark, TableLookupVersusLiveCalculation )
             // increment phase
             phase += phaseStep;
 
-            // and be sure to keep phase within range (-MAX_PHASE to +MAX_PHASE)
-            if ( phase > MAX_PHASE )
-                phase -= MAX_PHASE;
+            // and be sure to keep phase within range (-1.0 to +1.0)
+            if ( phase > 1.0 )
+                phase -= 1.0;
         }
     }
 

--- a/src/main/cpp/tests/benchmarks/table_test.cpp
+++ b/src/main/cpp/tests/benchmarks/table_test.cpp
@@ -54,7 +54,7 @@ TEST( TableBenchmark, TableLookupVersusLiveCalculation )
             // increment phase
             phase += phaseStep;
 
-            // and be sure to keep phase within range (-1.0 to +1.0)
+            // and be sure to keep phase within range
             if ( phase > 1.0 )
                 phase -= 1.0;
         }

--- a/src/main/cpp/tests/events/baseaudioevent_test.cpp
+++ b/src/main/cpp/tests/events/baseaudioevent_test.cpp
@@ -7,7 +7,7 @@ TEST( BaseAudioEvent, GettersSettersVolume )
 {
     BaseAudioEvent* audioEvent = new BaseAudioEvent();
 
-    EXPECT_EQ( audioEvent->getVolume(), MAX_PHASE )
+    EXPECT_EQ( audioEvent->getVolume(), 1.0 )
         << "expected default volume to be equal to the maximum phase value";
 
     float volume = randomFloat();

--- a/src/main/cpp/tests/events/basesynthevent_test.cpp
+++ b/src/main/cpp/tests/events/basesynthevent_test.cpp
@@ -69,8 +69,8 @@ TEST( BaseSynthEvent, Envelopes )
     EXPECT_FLOAT_EQ( audioEvent->cachedProps.releaseLevel, instrument->adsr->getSustainLevel() )
         << "expected events release level by default to equal the ADSR sustain level";
 
-    EXPECT_FLOAT_EQ( audioEvent->cachedProps.envelope, MAX_PHASE )
-        << "expected events envelope to be MAX_PHASE after construction for a 0 attack ADSR";
+    EXPECT_FLOAT_EQ( audioEvent->cachedProps.envelope, 1.0 )
+        << "expected events envelope to be 1.0 after construction for a 0 attack ADSR";
 
     EXPECT_EQ( audioEvent->cachedProps.envelopeOffset, 0 )
         << "expected events envelope offset to be 0 after construction";
@@ -377,7 +377,7 @@ TEST( BaseSynthEvent, Play )
 
     audioEvent->released = true;
     audioEvent->setDeletable( true );
-    audioEvent->cachedProps.envelope       = MAX_PHASE;
+    audioEvent->cachedProps.envelope       = 1.0;
     audioEvent->cachedProps.envelopeOffset = 1000;
 
     audioEvent->play();

--- a/src/main/cpp/tests/generators/envelopegenerator_test.cpp
+++ b/src/main/cpp/tests/generators/envelopegenerator_test.cpp
@@ -8,8 +8,8 @@ TEST( EnvelopeGenerator, GenerateLinear )
 
     int length = randomInt( 24, 512 );
 
-    SAMPLE_TYPE startAmplitude = randomSample( 0.0, MAX_PHASE );
-    SAMPLE_TYPE endAmplitude   = randomSample( 0.0, MAX_PHASE );
+    SAMPLE_TYPE startAmplitude = randomSample( 0.0, 1.0 );
+    SAMPLE_TYPE endAmplitude   = randomSample( 0.0, 1.0 );
 
     bool fadeIn = ( endAmplitude > startAmplitude );
 
@@ -20,7 +20,7 @@ TEST( EnvelopeGenerator, GenerateLinear )
     // evaluate results
 
     SAMPLE_TYPE sample;
-    SAMPLE_TYPE lastSample = fadeIn ? 0.0f : MAX_PHASE;
+    SAMPLE_TYPE lastSample = fadeIn ? 0.0f : 1.0;
 
     for ( int i = 0; i < length; ++i )
     {

--- a/src/main/cpp/tests/helpers/helper.cpp
+++ b/src/main/cpp/tests/helpers/helper.cpp
@@ -112,7 +112,7 @@ AudioBuffer* fillAudioBuffer( AudioBuffer* audioBuffer )
         SAMPLE_TYPE* buffer = audioBuffer->getBufferForChannel( c );
 
         for ( int i = 0, l = audioBuffer->bufferSize; i < l; ++i )
-            buffer[ i ] = randomSample( -MAX_PHASE, +MAX_PHASE );
+            buffer[ i ] = randomSample( -1.0, +1.0 );
     }
     return audioBuffer;
 }
@@ -121,7 +121,7 @@ AudioBuffer* fillAudioBuffer( AudioBuffer* audioBuffer )
 
 SAMPLE_TYPE getMaxAmpForBuffer( AudioBuffer* audioBuffer )
 {
-    SAMPLE_TYPE max = -MAX_PHASE;
+    SAMPLE_TYPE max = -1.0;
 
     for ( int c = 0, ca = audioBuffer->amountOfChannels; c < ca; ++c )
     {

--- a/src/main/cpp/tests/modules/adsr_test.cpp
+++ b/src/main/cpp/tests/modules/adsr_test.cpp
@@ -8,10 +8,10 @@
 TEST( ADSR, Constructor ) {
     ADSR* adsr = new ADSR();
 
-    EXPECT_EQ( 0,         adsr->getAttackTime() )   << "expected value to be 0 by default";
-    EXPECT_EQ( 0,         adsr->getDecayTime() )    << "expected value to be 0 by default";
+    EXPECT_EQ( 0,   adsr->getAttackTime() )   << "expected value to be 0 by default";
+    EXPECT_EQ( 0,   adsr->getDecayTime() )    << "expected value to be 0 by default";
     EXPECT_EQ( 1.0, adsr->getSustainLevel() ) << "expected value to be 1.0 by default";
-    EXPECT_EQ( 0,         adsr->getReleaseTime() )  << "expected value to be 0 by default";
+    EXPECT_EQ( 0,   adsr->getReleaseTime() )  << "expected value to be 0 by default";
 
     delete adsr;
 }
@@ -51,8 +51,8 @@ TEST( ADSR, ReleaseDuration )
 }
 
 TEST( ADSR, ApplyPositiveSustain ) {
-    float HALF_PHASE    = 1.0 / 2;
-    float QUARTER_PHASE = 1.0 / 4;
+    float HALF_PHASE    = 0.5f;
+    float QUARTER_PHASE = 0.25f;
 
     int bufferLength = 8;
     SynthInstrument* instrument = new SynthInstrument();
@@ -118,8 +118,8 @@ TEST( ADSR, ApplyPositiveSustain ) {
 }
 
 TEST( ADSR, ApplyZeroSustain ) {
-    float HALF_PHASE    = 1.0 / 2;
-    float QUARTER_PHASE = 1.0 / 4;
+    float HALF_PHASE    = 0.5f;
+    float QUARTER_PHASE = 0.25f;
 
     int bufferLength = 16;
     SynthInstrument* instrument = new SynthInstrument();
@@ -184,8 +184,8 @@ TEST( ADSR, ApplyZeroSustain ) {
 }
 
 TEST( ADSR, ApplyOnLiveEvent ) {
-    float HALF_PHASE    = 1.0 / 2;
-    float QUARTER_PHASE = 1.0 / 4;
+    float HALF_PHASE    = 0.5f;
+    float QUARTER_PHASE = 0.25f;
 
     int bufferLength = 8;
     SynthInstrument* instrument = new SynthInstrument();
@@ -274,8 +274,8 @@ TEST( ADSR, ApplyOnLiveEvent ) {
 
 TEST( ADSR, LastEnvelope )
 {
-    float HALF_PHASE    = 1.0 / 2;
-    float QUARTER_PHASE = 1.0 / 4;
+    float HALF_PHASE    = 0.5f;
+    float QUARTER_PHASE = 0.25f;
 
     int bufferLength = 8;
     SynthInstrument* instrument = new SynthInstrument();

--- a/src/main/cpp/tests/modules/adsr_test.cpp
+++ b/src/main/cpp/tests/modules/adsr_test.cpp
@@ -10,7 +10,7 @@ TEST( ADSR, Constructor ) {
 
     EXPECT_EQ( 0,         adsr->getAttackTime() )   << "expected value to be 0 by default";
     EXPECT_EQ( 0,         adsr->getDecayTime() )    << "expected value to be 0 by default";
-    EXPECT_EQ( MAX_PHASE, adsr->getSustainLevel() ) << "expected value to be 1.0 by default";
+    EXPECT_EQ( 1.0, adsr->getSustainLevel() ) << "expected value to be 1.0 by default";
     EXPECT_EQ( 0,         adsr->getReleaseTime() )  << "expected value to be 0 by default";
 
     delete adsr;
@@ -51,8 +51,8 @@ TEST( ADSR, ReleaseDuration )
 }
 
 TEST( ADSR, ApplyPositiveSustain ) {
-    float HALF_PHASE    = MAX_PHASE / 2;
-    float QUARTER_PHASE = MAX_PHASE / 4;
+    float HALF_PHASE    = 1.0 / 2;
+    float QUARTER_PHASE = 1.0 / 4;
 
     int bufferLength = 8;
     SynthInstrument* instrument = new SynthInstrument();
@@ -77,7 +77,7 @@ TEST( ADSR, ApplyPositiveSustain ) {
 
     // fill buffer with maximum volume samples
     for ( int i = 0; i < inputBuffer->bufferSize; ++i )
-        buffer[ i ] = MAX_PHASE;
+        buffer[ i ] = 1.0;
 
     // apply ADSR envelopes
     adsr->apply( inputBuffer, synthEvent, 0 );
@@ -92,8 +92,8 @@ TEST( ADSR, ApplyPositiveSustain ) {
     EXPECT_FLOAT_EQ( buffer[ 1 ], HALF_PHASE );
 
     // decay phase
-    EXPECT_FLOAT_EQ( buffer[ 2 ], MAX_PHASE );
-    EXPECT_FLOAT_EQ( buffer[ 3 ], MAX_PHASE - QUARTER_PHASE );
+    EXPECT_FLOAT_EQ( buffer[ 2 ], 1.0 );
+    EXPECT_FLOAT_EQ( buffer[ 3 ], 1.0 - QUARTER_PHASE );
 
     // sustain phase
     EXPECT_FLOAT_EQ( buffer[ 4 ], HALF_PHASE );
@@ -118,8 +118,8 @@ TEST( ADSR, ApplyPositiveSustain ) {
 }
 
 TEST( ADSR, ApplyZeroSustain ) {
-    float HALF_PHASE    = MAX_PHASE / 2;
-    float QUARTER_PHASE = MAX_PHASE / 4;
+    float HALF_PHASE    = 1.0 / 2;
+    float QUARTER_PHASE = 1.0 / 4;
 
     int bufferLength = 16;
     SynthInstrument* instrument = new SynthInstrument();
@@ -143,7 +143,7 @@ TEST( ADSR, ApplyZeroSustain ) {
 
     // fill buffer with maximum volume samples
     for ( int i = 0; i < inputBuffer->bufferSize; ++i )
-        buffer[ i ] = MAX_PHASE;
+        buffer[ i ] = 1.0;
 
     // apply ADSR envelopes
     adsr->apply( inputBuffer, synthEvent, 0 );
@@ -158,8 +158,8 @@ TEST( ADSR, ApplyZeroSustain ) {
     EXPECT_FLOAT_EQ( buffer[ 1 ], HALF_PHASE );
 
     // decay phase
-    EXPECT_FLOAT_EQ( buffer[ 2 ], MAX_PHASE );
-    EXPECT_FLOAT_EQ( buffer[ 3 ], MAX_PHASE - QUARTER_PHASE );
+    EXPECT_FLOAT_EQ( buffer[ 2 ], 1.0 );
+    EXPECT_FLOAT_EQ( buffer[ 3 ], 1.0 - QUARTER_PHASE );
 
     // sustain phase
     EXPECT_FLOAT_EQ( buffer[ 4 ], HALF_PHASE );
@@ -184,8 +184,8 @@ TEST( ADSR, ApplyZeroSustain ) {
 }
 
 TEST( ADSR, ApplyOnLiveEvent ) {
-    float HALF_PHASE    = MAX_PHASE / 2;
-    float QUARTER_PHASE = MAX_PHASE / 4;
+    float HALF_PHASE    = 1.0 / 2;
+    float QUARTER_PHASE = 1.0 / 4;
 
     int bufferLength = 8;
     SynthInstrument* instrument = new SynthInstrument();
@@ -212,7 +212,7 @@ TEST( ADSR, ApplyOnLiveEvent ) {
 
     // fill buffer with maximum volume samples
     for ( int i = 0; i < inputBuffer->bufferSize; ++i )
-        buffer[ i ] = MAX_PHASE;
+        buffer[ i ] = 1.0;
 
     // apply ADSR envelopes
     adsr->apply( inputBuffer, synthEvent, 0 );
@@ -227,8 +227,8 @@ TEST( ADSR, ApplyOnLiveEvent ) {
     EXPECT_FLOAT_EQ( buffer[ 1 ], HALF_PHASE );
 
     // decay phase
-    EXPECT_FLOAT_EQ( buffer[ 2 ], MAX_PHASE );
-    EXPECT_FLOAT_EQ( buffer[ 3 ], MAX_PHASE - QUARTER_PHASE );
+    EXPECT_FLOAT_EQ( buffer[ 2 ], 1.0 );
+    EXPECT_FLOAT_EQ( buffer[ 3 ], 1.0 - QUARTER_PHASE );
 
     // sustain phase (longer as the release phase is only initiated when synthEvent is released
     EXPECT_FLOAT_EQ( buffer[ 4 ], HALF_PHASE );
@@ -239,7 +239,7 @@ TEST( ADSR, ApplyOnLiveEvent ) {
     // TEST 2. released event
     // fill buffer with maximum volume samples again
     for ( int i = 0; i < inputBuffer->bufferSize; ++i )
-        buffer[ i ] = MAX_PHASE;
+        buffer[ i ] = 1.0;
 
     // release event (by stopping)
     synthEvent->stop();
@@ -274,8 +274,8 @@ TEST( ADSR, ApplyOnLiveEvent ) {
 
 TEST( ADSR, LastEnvelope )
 {
-    float HALF_PHASE    = MAX_PHASE / 2;
-    float QUARTER_PHASE = MAX_PHASE / 4;
+    float HALF_PHASE    = 1.0 / 2;
+    float QUARTER_PHASE = 1.0 / 4;
 
     int bufferLength = 8;
     SynthInstrument* instrument = new SynthInstrument();
@@ -296,7 +296,7 @@ TEST( ADSR, LastEnvelope )
 
     // fill buffer with maximum volume samples
     for ( int i = 0; i < inputBuffer->bufferSize; ++i )
-        buffer[ i ] = MAX_PHASE;
+        buffer[ i ] = 1.0;
 
     EXPECT_FLOAT_EQ( 0.0, synthEvent->cachedProps.envelope )
         << "expected cached envelope to be 0 at start of application";

--- a/src/main/cpp/tests/processors/reverb_test.cpp
+++ b/src/main/cpp/tests/processors/reverb_test.cpp
@@ -5,17 +5,17 @@ TEST( Reverb, GetSetSize )
     Reverb* reverb = new Reverb( 0.f, 0.f, 0.f, 0.f );
 
     float min = 0.f;
-    float max = MAX_PHASE;
+    float max = 1.0;
 
     float value = randomFloat( min, max );
 
     reverb->setSize( value );
     EXPECT_EQ( value, reverb->getSize() ) << "expected set size to have been returned unchanged";
 
-    reverb->setSize( -MAX_PHASE );
+    reverb->setSize( -1.0 );
     EXPECT_EQ( min, reverb->getSize() ) << "expected size to have been normalized to defined min value";
 
-    reverb->setSize( MAX_PHASE * 2 );
+    reverb->setSize( 1.0 * 2 );
     EXPECT_EQ( max, reverb->getSize() ) << "expected size to have been normalized to defined max value";
 
     delete reverb;
@@ -26,17 +26,17 @@ TEST( Reverb, GetSetHFDamp )
     Reverb* reverb = new Reverb( 0.f, 0.f, 0.f, 0.f );
 
     float min = 0.f;
-    float max = MAX_PHASE;
+    float max = 1.0;
 
     float value = randomFloat( min, max );
 
     reverb->setHFDamp( value );
     EXPECT_EQ( value, reverb->getHFDamp() ) << "expected set damp to have been returned unchanged";
 
-    reverb->setHFDamp( -MAX_PHASE );
+    reverb->setHFDamp( -1.0 );
     EXPECT_EQ( min, reverb->getHFDamp() ) << "expected damp to have been normalized to defined min value";
 
-    reverb->setHFDamp( MAX_PHASE * 2 );
+    reverb->setHFDamp( 1.0 * 2 );
     EXPECT_EQ( max, reverb->getHFDamp() ) << "expected damp to have been normalized to defined max value";
 
     delete reverb;
@@ -47,17 +47,17 @@ TEST( Reverb, GetSetMix )
     Reverb* reverb = new Reverb( 0.f, 0.f, 0.f, 0.f );
 
     float min = 0.f;
-    float max = MAX_PHASE;
+    float max = 1.0;
 
     float value = randomFloat( min, max );
 
     reverb->setMix( value );
     EXPECT_EQ( value, reverb->getMix() ) << "expected set mix to have been returned unchanged";
 
-    reverb->setMix( -MAX_PHASE );
+    reverb->setMix( -1.0 );
     EXPECT_EQ( min, reverb->getMix() ) << "expected mix to have been normalized to defined min value";
 
-    reverb->setMix( MAX_PHASE * 2 );
+    reverb->setMix( 1.0 * 2 );
     EXPECT_EQ( max, reverb->getMix() ) << "expected mix to have been normalized to defined max value";
 
     delete reverb;
@@ -68,17 +68,17 @@ TEST( Reverb, GetSetOutput )
     Reverb* reverb = new Reverb( 0.f, 0.f, 0.f, 0.f );
 
     float min = 0.f;
-    float max = MAX_PHASE;
+    float max = 1.0;
 
     float value = randomFloat( min, max );
 
     reverb->setOutput( value );
     EXPECT_EQ( value, reverb->getOutput() ) << "expected set output to have been returned unchanged";
 
-    reverb->setOutput( -MAX_PHASE );
+    reverb->setOutput( -1.0 );
     EXPECT_EQ( min, reverb->getOutput() ) << "expected output to have been normalized to defined min value";
 
-    reverb->setOutput( MAX_PHASE * 2 );
+    reverb->setOutput( 1.0 * 2 );
     EXPECT_EQ( max, reverb->getOutput() ) << "expected output to have been normalized to defined max value";
 
     delete reverb;

--- a/src/main/cpp/tests/processors/reverb_test.cpp
+++ b/src/main/cpp/tests/processors/reverb_test.cpp
@@ -15,7 +15,7 @@ TEST( Reverb, GetSetSize )
     reverb->setSize( -1.0 );
     EXPECT_EQ( min, reverb->getSize() ) << "expected size to have been normalized to defined min value";
 
-    reverb->setSize( 1.0 * 2 );
+    reverb->setSize( 2.0 );
     EXPECT_EQ( max, reverb->getSize() ) << "expected size to have been normalized to defined max value";
 
     delete reverb;
@@ -36,7 +36,7 @@ TEST( Reverb, GetSetHFDamp )
     reverb->setHFDamp( -1.0 );
     EXPECT_EQ( min, reverb->getHFDamp() ) << "expected damp to have been normalized to defined min value";
 
-    reverb->setHFDamp( 1.0 * 2 );
+    reverb->setHFDamp( 2.0 );
     EXPECT_EQ( max, reverb->getHFDamp() ) << "expected damp to have been normalized to defined max value";
 
     delete reverb;
@@ -57,7 +57,7 @@ TEST( Reverb, GetSetMix )
     reverb->setMix( -1.0 );
     EXPECT_EQ( min, reverb->getMix() ) << "expected mix to have been normalized to defined min value";
 
-    reverb->setMix( 1.0 * 2 );
+    reverb->setMix( 2.0 );
     EXPECT_EQ( max, reverb->getMix() ) << "expected mix to have been normalized to defined max value";
 
     delete reverb;

--- a/src/main/cpp/tests/processors/reverb_test.cpp
+++ b/src/main/cpp/tests/processors/reverb_test.cpp
@@ -12,10 +12,10 @@ TEST( Reverb, GetSetSize )
     reverb->setSize( value );
     EXPECT_EQ( value, reverb->getSize() ) << "expected set size to have been returned unchanged";
 
-    reverb->setSize( -1.0 );
+    reverb->setSize( -max );
     EXPECT_EQ( min, reverb->getSize() ) << "expected size to have been normalized to defined min value";
 
-    reverb->setSize( 2.0 );
+    reverb->setSize( max * 2 );
     EXPECT_EQ( max, reverb->getSize() ) << "expected size to have been normalized to defined max value";
 
     delete reverb;
@@ -33,10 +33,10 @@ TEST( Reverb, GetSetHFDamp )
     reverb->setHFDamp( value );
     EXPECT_EQ( value, reverb->getHFDamp() ) << "expected set damp to have been returned unchanged";
 
-    reverb->setHFDamp( -1.0 );
+    reverb->setHFDamp( -max );
     EXPECT_EQ( min, reverb->getHFDamp() ) << "expected damp to have been normalized to defined min value";
 
-    reverb->setHFDamp( 2.0 );
+    reverb->setHFDamp( max * 2 );
     EXPECT_EQ( max, reverb->getHFDamp() ) << "expected damp to have been normalized to defined max value";
 
     delete reverb;
@@ -54,10 +54,10 @@ TEST( Reverb, GetSetMix )
     reverb->setMix( value );
     EXPECT_EQ( value, reverb->getMix() ) << "expected set mix to have been returned unchanged";
 
-    reverb->setMix( -1.0 );
+    reverb->setMix( -max );
     EXPECT_EQ( min, reverb->getMix() ) << "expected mix to have been normalized to defined min value";
 
-    reverb->setMix( 2.0 );
+    reverb->setMix( max * 2 );
     EXPECT_EQ( max, reverb->getMix() ) << "expected mix to have been normalized to defined max value";
 
     delete reverb;
@@ -75,10 +75,10 @@ TEST( Reverb, GetSetOutput )
     reverb->setOutput( value );
     EXPECT_EQ( value, reverb->getOutput() ) << "expected set output to have been returned unchanged";
 
-    reverb->setOutput( -1.0 );
+    reverb->setOutput( -max );
     EXPECT_EQ( min, reverb->getOutput() ) << "expected output to have been normalized to defined min value";
 
-    reverb->setOutput( 1.0 * 2 );
+    reverb->setOutput( max * 2 );
     EXPECT_EQ( max, reverb->getOutput() ) << "expected output to have been normalized to defined max value";
 
     delete reverb;

--- a/src/main/cpp/utilities/diskwriter.cpp
+++ b/src/main/cpp/utilities/diskwriter.cpp
@@ -67,7 +67,7 @@ namespace DiskWriter
         if ( cachedBuffer == 0 )
             generateOutputBuffer( channelAmount );
 
-        cachedBuffer->mergeBuffers( aBuffer, 0, outputWriterIndex, MAX_PHASE );
+        cachedBuffer->mergeBuffers( aBuffer, 0, outputWriterIndex, 1.0 );
         outputWriterIndex += bufferSize;
     }
 

--- a/src/main/cpp/utilities/utils.h
+++ b/src/main/cpp/utilities/utils.h
@@ -38,11 +38,12 @@ inline float capParam( float value )
     return std::min( 1.f, std::max( 0.f, value ));
 }
 
-// convenience method to ensure a sample is in the valid -1.f - +1.f range
+// convenience method to ensure a sample is within the valid -1.f to +1.f range
+// this prevents audio exceeding the maximum head room
 
 inline SAMPLE_TYPE capSample( SAMPLE_TYPE value )
 {
-    return std::min( 1.0, std::max( -1.0, value ));
+    return std::min(( SAMPLE_TYPE ) 1.0, std::max(( SAMPLE_TYPE ) -1.0, value ));
 }
 
 /* convenience methods */

--- a/src/main/cpp/utilities/volumeutil.h
+++ b/src/main/cpp/utilities/volumeutil.h
@@ -28,12 +28,12 @@
 
 // a convenient macro which is used to mix in a sample
 // into an existing audio buffer preventing overflowing
-// the range (defined by MAX_PHASE) which in turn will lead to clipping
-// MAX_PHASE defines the maximum value for the sample (+1.f for a float based range)
+// the range (defined by 1.0) which in turn will lead to clipping
+// 1.0 defines the maximum value for the sample (+1.f for a float based range)
 // sampleBase = your base audio sample
 // sampleToAdd = sample to add to base
 
-#define SUM_SAMPLES( sampleBase, sampleToAdd ) ((( MAX_PHASE - (sampleBase)) * (sampleToAdd)) / MAX_PHASE ) + (sampleBase)
+#define SUM_SAMPLES( sampleBase, sampleToAdd ) ((( 1.0 - (sampleBase)) * (sampleToAdd)) / 1.0 ) + (sampleBase)
 
 namespace VolumeUtil
 {

--- a/src/main/cpp/utilities/waveutil.h
+++ b/src/main/cpp/utilities/waveutil.h
@@ -31,7 +31,7 @@ namespace WaveUtil
      */
     inline void toUnipolar( SAMPLE_TYPE* buffer, int bufferSize )
     {
-        SAMPLE_TYPE halfPhase = MAX_PHASE / 2.f;
+        SAMPLE_TYPE halfPhase = 1.0 / 2.f;
         for ( int i = 0; i < bufferSize; ++i ) {
             buffer[ i ] = buffer[ i ] * halfPhase + halfPhase;
         }
@@ -44,7 +44,7 @@ namespace WaveUtil
     inline void toBipolar( SAMPLE_TYPE* buffer, int bufferSize )
     {
         for ( int i = 0; i < bufferSize; ++i ) {
-            buffer[ i ] = buffer[ i ] * ( MAX_PHASE * 2.f ) - MAX_PHASE;
+            buffer[ i ] = buffer[ i ] * ( 1.0 * 2.f ) - 1.0;
         }
     }
 

--- a/src/main/cpp/utilities/waveutil.h
+++ b/src/main/cpp/utilities/waveutil.h
@@ -31,7 +31,7 @@ namespace WaveUtil
      */
     inline void toUnipolar( SAMPLE_TYPE* buffer, int bufferSize )
     {
-        SAMPLE_TYPE halfPhase = 1.0 / 2.f;
+        SAMPLE_TYPE halfPhase = 0.5f;
         for ( int i = 0; i < bufferSize; ++i ) {
             buffer[ i ] = buffer[ i ] * halfPhase + halfPhase;
         }
@@ -44,7 +44,7 @@ namespace WaveUtil
     inline void toBipolar( SAMPLE_TYPE* buffer, int bufferSize )
     {
         for ( int i = 0; i < bufferSize; ++i ) {
-            buffer[ i ] = buffer[ i ] * ( 1.0 * 2.f ) - 1.0;
+            buffer[ i ] = buffer[ i ] * 2.0 - 1.0;
         }
     }
 


### PR DESCRIPTION
Inside _global.h_ MAX_PHASE was defined. This would always be 1.0 to imply a maximum audio signal range of -1.0f to +1.0f. There is no real need for this constant, especially as other values (e.g. lower) can be achieved with volume control of the AudioChannels. Higher values will lead to clipping on the output so are undesirable...