### PR TITLE
Fix typo in audioengine.cpp, rename recBuffer -> recbuffer

### DIFF
--- a/src/main/cpp/audioengine.cpp
+++ b/src/main/cpp/audioengine.cpp
@@ -64,7 +64,7 @@ namespace AudioEngine
     float* recbufferIn = 0;
 
     AudioBuffer* inBuffer  = 0;
-    AudioBuffer* recBuffer = 0;
+    AudioBuffer* recbuffer = 0;
     std::vector<AudioChannel*>* channels = 0;
 
     /* tempo / sequencer position related */


### PR DESCRIPTION
This will let MWEngine compile if #define RECORD_DEVICE_INPUT in global.h is uncommented