### PR TITLE
Replace usage of 0 with nullptr where applicable

### DIFF
--- a/src/main/cpp/audiobuffer.cpp
+++ b/src/main/cpp/audiobuffer.cpp
@@ -42,6 +42,7 @@ AudioBuffer::~AudioBuffer()
         delete[] _buffers->back(), _buffers->pop_back();
     }
     delete _buffers;
+    _buffers = nullptr;
 }
 
 /* public methods */
@@ -53,7 +54,7 @@ SAMPLE_TYPE* AudioBuffer::getBufferForChannel( int aChannelNum )
 
 int AudioBuffer::mergeBuffers( AudioBuffer* aBuffer, int aReadOffset, int aWriteOffset, float aMixVolume )
 {
-    if ( aBuffer == 0 || aWriteOffset >= bufferSize )
+    if ( aBuffer == nullptr || aWriteOffset >= bufferSize )
         return 0;
 
     int sourceLength     = aBuffer->bufferSize;

--- a/src/main/cpp/audiochannel.cpp
+++ b/src/main/cpp/audiochannel.cpp
@@ -48,6 +48,10 @@ AudioChannel::~AudioChannel()
     delete _outputBuffer;
     delete _cachedBuffer;
     delete processingChain;
+
+    _outputBuffer   = nullptr;
+    _cachedBuffer   = nullptr;
+    processingChain = nullptr;
 }
 
 /* public methods */
@@ -101,12 +105,12 @@ void AudioChannel::canCache( bool value, int aBufferSize, int aCacheStartOffset,
     _cacheStartOffset = aCacheStartOffset;
     _cacheEndOffset   = aCacheEndOffset;
 
-    if ( !value || ( _cachedBuffer != 0 && _cachedBuffer->bufferSize != aBufferSize ))
+    if ( !value || ( _cachedBuffer != nullptr && _cachedBuffer->bufferSize != aBufferSize ))
         clearCachedBuffer();
 
     if ( value )
     {
-        if ( _cachedBuffer == 0 )
+        if ( _cachedBuffer == nullptr )
             _cachedBuffer = new AudioBuffer( AudioEngineProps::OUTPUT_CHANNELS, aBufferSize );
     }
     isCaching = value;
@@ -117,7 +121,7 @@ void AudioChannel::createOutputBuffer()
     int bufferSize     = AudioEngineProps::BUFFER_SIZE;
     int outputChannels = AudioEngineProps::OUTPUT_CHANNELS;
 
-    if ( _outputBuffer != 0 )
+    if ( _outputBuffer != nullptr )
     {
         if ( _outputBuffer->bufferSize       == bufferSize &&
              _outputBuffer->amountOfChannels == outputChannels )
@@ -194,10 +198,10 @@ void AudioChannel::writeCache( AudioBuffer* aBuffer, int aReadOffset )
 
 void AudioChannel::clearCachedBuffer()
 {
-    if ( _cachedBuffer != 0 )
+    if ( _cachedBuffer != nullptr )
     {
         delete _cachedBuffer;
-        _cachedBuffer = 0;
+        _cachedBuffer = nullptr;
     }
     hasCache  = false;
     isCaching = _canCache;
@@ -232,8 +236,8 @@ void AudioChannel::init()
     isCaching          = false;
     instanceId         = ++INSTANCE_COUNT;
     _canCache          = false;
-    _outputBuffer      = 0;
-    _cachedBuffer      = 0;
+    _outputBuffer      = nullptr;
+    _cachedBuffer      = nullptr;
     _cacheReadPointer  = 0;
     _cacheWritePointer = 0;
     _cacheStartOffset  = 0;

--- a/src/main/cpp/audioengine.cpp
+++ b/src/main/cpp/audioengine.cpp
@@ -59,16 +59,16 @@ namespace AudioEngine
 
     int outputChannels = AudioEngineProps::OUTPUT_CHANNELS;
     bool isMono        = ( outputChannels == 1 );
-    float* outBuffer   = 0;
+    float* outBuffer   = nullptr;
 
 #ifdef RECORD_DEVICE_INPUT
-    float* recbufferIn         = 0;
+    float* recbufferIn         = nullptr;
     AudioChannel* inputChannel = new AudioChannel( 1.0f );
     bool recordDeviceInput     = false;
 #endif
 
-    AudioBuffer* inBuffer  = 0;
-    std::vector<AudioChannel*>* channels = 0;
+    AudioBuffer* inBuffer                = nullptr;
+    std::vector<AudioChannel*>* channels = nullptr;
 
     /* tempo / sequencer position related */
 
@@ -179,8 +179,14 @@ namespace AudioEngine
         delete channels;
         delete outBuffer;
         delete inBuffer;
+
+        channels  = nullptr;
+        outBuffer = nullptr;
+        inBuffer  = nullptr;
+
 #ifdef RECORD_DEVICE_INPUT
         delete recbufferIn;
+        recBufferIn = nullptr;
 #endif
     }
 
@@ -299,7 +305,7 @@ namespace AudioEngine
                     {
                         BaseAudioEvent* audioEvent = audioEvents[ k ];
 
-                        if ( audioEvent != 0 && !audioEvent->isLocked()) // make sure we're allowed to query the contents
+                        if ( audioEvent != nullptr && !audioEvent->isLocked()) // make sure we're allowed to query the contents
                         {
                             audioEvent->mixBuffer( channelBuffer, bufferPos, min_buffer_position,
                                                    maxBufferPosition, loopStarted, loopOffset, useChannelRange );
@@ -633,7 +639,7 @@ AudioChannel* getInputChannel( JNIEnv* env, jobject jobj )
 #ifdef RECORD_DEVICE_INPUT
     return AudioEngine::inputChannel;
 #else
-    return 0;
+    return nullptr;
 #endif
 }
 

--- a/src/main/cpp/events/baseaudioevent.cpp
+++ b/src/main/cpp/events/baseaudioevent.cpp
@@ -60,7 +60,7 @@ void BaseAudioEvent::setInstrument( BaseInstrument* aInstrument )
     // additionally, if event was added to the sequencer, add it to the new
     // instruments sequenced events list
 
-    if ( aInstrument != 0 &&
+    if ( aInstrument != nullptr &&
         _instrument  != aInstrument )
     {
         bool wasAddedToSequencer = _addedToSequencer;
@@ -77,7 +77,7 @@ void BaseAudioEvent::setInstrument( BaseInstrument* aInstrument )
 
 void BaseAudioEvent::play()
 {
-    if ( _livePlayback || _instrument == 0 )
+    if ( _livePlayback || _instrument == nullptr )
         return;
 
     setDeletable( false );
@@ -118,7 +118,7 @@ void BaseAudioEvent::addToSequencer()
 
 void BaseAudioEvent::removeFromSequencer()
 {
-    if ( !_addedToSequencer || _instrument == 0 )
+    if ( !_addedToSequencer || _instrument == nullptr )
         return;
 
     if ( !isSequenced )
@@ -129,7 +129,7 @@ void BaseAudioEvent::removeFromSequencer()
     {
         std::vector<BaseAudioEvent*>* events = _instrument->getEvents();
 
-        if ( events != 0 ) {
+        if ( events != nullptr ) {
             std::vector<BaseAudioEvent*>::iterator position = std::find( events->begin(),
                                                                          events->end(), this );
             if ( position != events->end() )
@@ -290,7 +290,7 @@ void BaseAudioEvent::setLoopeable( bool value )
 {
     _loopeable = value;
 
-    if ( _buffer != 0 )
+    if ( _buffer != nullptr )
         _buffer->loopeable = _loopeable;
 }
 
@@ -489,7 +489,7 @@ void BaseAudioEvent::setBuffer( AudioBuffer* buffer, bool destroyable )
 
 bool BaseAudioEvent::hasBuffer()
 {
-    return _buffer != 0;
+    return _buffer != nullptr;
 }
 
 AudioBuffer* BaseAudioEvent::synthesize( int aBufferLength )
@@ -504,7 +504,7 @@ AudioBuffer* BaseAudioEvent::synthesize( int aBufferLength )
 
 void BaseAudioEvent::construct()
 {
-    _buffer            = 0;
+    _buffer            = nullptr;
     _enabled           = true;
     _destroyableBuffer = true;
     _loopeable         = false;
@@ -517,7 +517,7 @@ void BaseAudioEvent::construct()
     _readPointer       = 0;
     _startPosition     = 0.f;
     _endPosition       = 0.f;
-    _instrument        = 0;
+    _instrument        = nullptr;
     _deleteMe          = false;
     _livePlayback      = false;
     isSequenced        = true;
@@ -525,10 +525,10 @@ void BaseAudioEvent::construct()
 
 void BaseAudioEvent::destroyBuffer()
 {
-    if ( _destroyableBuffer && _buffer != 0 )
+    if ( _destroyableBuffer && _buffer != nullptr )
     {
         delete _buffer;
-        _buffer = 0;
+        _buffer = nullptr;
     }
 }
 

--- a/src/main/cpp/events/basecacheableaudioevent.cpp
+++ b/src/main/cpp/events/basecacheableaudioevent.cpp
@@ -59,7 +59,7 @@ void BaseCacheableAudioEvent::setAutoCache( bool aValue )
  */
 void BaseCacheableAudioEvent::cache( bool doCallback )
 {
-    if ( _buffer == 0 ) return; // cache request likely invoked after destruction
+    if ( _buffer == nullptr ) return; // cache request likely invoked after destruction
 
     _caching = true;
 

--- a/src/main/cpp/events/basesynthevent.cpp
+++ b/src/main/cpp/events/basesynthevent.cpp
@@ -33,7 +33,7 @@ unsigned int BaseSynthEvent::INSTANCE_COUNT = 0;
 
 BaseSynthEvent::BaseSynthEvent()
 {
-    _synthInstrument = 0;
+    _synthInstrument = nullptr;
 }
 
 /**
@@ -204,10 +204,10 @@ void BaseSynthEvent::calculateBuffers()
     // buffer is only instantiated once as it is the size of the engines BUFFER_SIZE
     // (this event will not be cached in its entirety but will repeatedly render snippets into its buffer)
 
-    if ( _buffer == 0 )
+    if ( _buffer == nullptr )
         _buffer = new AudioBuffer( AudioEngineProps::OUTPUT_CHANNELS, AudioEngineProps::BUFFER_SIZE );
 
-    if ( isSequenced && _synthInstrument != 0 )
+    if ( isSequenced && _synthInstrument != nullptr )
          _synthInstrument->synthesizer->initializeEventProperties( this, true );
 }
 
@@ -296,7 +296,7 @@ void BaseSynthEvent::mixBuffer( AudioBuffer* outputBuffer, int bufferPos,
 AudioBuffer* BaseSynthEvent::synthesize( int aBufferLength )
 {
     // in case buffer length is unequal to cached length, create new write buffer
-    if ( aBufferLength != AudioEngineProps::BUFFER_SIZE || _buffer == 0 )
+    if ( aBufferLength != AudioEngineProps::BUFFER_SIZE || _buffer == nullptr )
     {
         destroyBuffer();
         _buffer = new AudioBuffer( AudioEngineProps::OUTPUT_CHANNELS, aBufferLength );

--- a/src/main/cpp/events/sampleevent.cpp
+++ b/src/main/cpp/events/sampleevent.cpp
@@ -42,6 +42,7 @@ SampleEvent::SampleEvent( BaseInstrument* aInstrument )
 SampleEvent::~SampleEvent()
 {
     delete _liveBuffer;
+    _liveBuffer = nullptr;
 }
 
 /* public methods */
@@ -76,7 +77,7 @@ void SampleEvent::setBufferRangeStart( int value )
 
     // buffer range may never exceed the length of the source buffer (which can be unequal to the sample length)
 
-    if ( _buffer != 0 && _bufferRangeEnd >= _buffer->bufferSize )
+    if ( _buffer != nullptr && _bufferRangeEnd >= _buffer->bufferSize )
         setBufferRangeEnd( _buffer->bufferSize - 1 );
 
     _bufferRangeLength = ( _bufferRangeEnd - _bufferRangeStart ) + 1;
@@ -91,7 +92,7 @@ int SampleEvent::getBufferRangeEnd()
 void SampleEvent::setBufferRangeEnd( int value )
 {
     // buffer range may never exceed the length of the source buffer (which can be unequal to the sample length)
-    _bufferRangeEnd = ( _buffer != 0 ) ? std::min( value, _buffer->bufferSize - 1 ): value;
+    _bufferRangeEnd = ( _buffer != nullptr ) ? std::min( value, _buffer->bufferSize - 1 ): value;
 
     if ( _rangePointer > _bufferRangeEnd )
         _rangePointer = _bufferRangeEnd;
@@ -131,9 +132,9 @@ unsigned int SampleEvent::getSampleRate()
  */
 AudioBuffer* SampleEvent::synthesize( int aBufferLength )
 {
-    if ( _liveBuffer == 0 )
+    if ( _liveBuffer == nullptr )
         _liveBuffer = new AudioBuffer(
-            ( _buffer != 0 ) ? _buffer->amountOfChannels : AudioEngineProps::OUTPUT_CHANNELS,
+            ( _buffer != nullptr ) ? _buffer->amountOfChannels : AudioEngineProps::OUTPUT_CHANNELS,
             AudioEngineProps::BUFFER_SIZE
         );
     else
@@ -172,7 +173,7 @@ void SampleEvent::setSample( AudioBuffer* sampleBuffer, unsigned int sampleRate 
     int sampleLength = sampleBuffer->bufferSize;
 
     // delete previous contents
-    if ( _eventLength != sampleLength || _buffer == 0 )
+    if ( _eventLength != sampleLength || _buffer == nullptr )
         destroyBuffer();
 
     // is this events buffer destroyable ? then clone
@@ -550,6 +551,6 @@ void SampleEvent::init( BaseInstrument* instrument )
     _destroyableBuffer     = false; // is referenced via SampleManager !
     _useBufferRange        = false;
     _instrument            = instrument;
-    _liveBuffer            = 0;
+    _liveBuffer            = nullptr;
     _sampleRate            = ( unsigned int ) AudioEngineProps::SAMPLE_RATE;
 }

--- a/src/main/cpp/generators/synthesizer.cpp
+++ b/src/main/cpp/generators/synthesizer.cpp
@@ -108,7 +108,7 @@ void Synthesizer::render( AudioBuffer* aOutputBuffer, BaseSynthEvent* aEvent )
 
     // WaveTable specific
 
-    WaveTable* waveTable = 0;
+    WaveTable* waveTable = nullptr;
     int tableReadOffset;
     SAMPLE_TYPE waveTableAccumulator;
     SAMPLE_TYPE* tableBuffer;
@@ -321,7 +321,7 @@ void Synthesizer::render( AudioBuffer* aOutputBuffer, BaseSynthEvent* aEvent )
 
     aEvent->setPhaseForOscillator( _oscillatorNum, phase );
 
-    if ( waveTable != 0 )
+    if ( waveTable != nullptr )
         waveTable->setAccumulator( waveTableAccumulator );
 }
 
@@ -382,7 +382,7 @@ void Synthesizer::destroyOscillator( int aOscillatorNum )
     Synthesizer* osc = _oscillators.at( aOscillatorNum );
     _oscillators.erase( _oscillators.begin() + aOscillatorNum );
 
-    if ( osc != 0 )
+    if ( osc != nullptr )
         delete osc;
 }
 

--- a/src/main/cpp/instruments/baseinstrument.cpp
+++ b/src/main/cpp/instruments/baseinstrument.cpp
@@ -41,9 +41,9 @@ BaseInstrument::~BaseInstrument()
     delete _audioEvents;
     delete _liveAudioEvents;
 
-    audioChannel     = 0;
-    _audioEvents     = 0;
-    _liveAudioEvents = 0;
+    audioChannel     = nullptr;
+    _audioEvents     = nullptr;
+    _liveAudioEvents = nullptr;
 }
 
 /* public methods */
@@ -98,13 +98,13 @@ void BaseInstrument::updateEvents()
 
 void BaseInstrument::clearEvents()
 {
-    if ( _audioEvents != 0 )
+    if ( _audioEvents != nullptr )
     {
         while ( _audioEvents->size() > 0 )
             removeEvent( _audioEvents->at( 0 ), false );
     }
 
-    if ( _liveAudioEvents != 0 )
+    if ( _liveAudioEvents != nullptr )
     {
         while ( _liveAudioEvents->size() > 0 )
             removeEvent( _liveAudioEvents->at( 0 ), true );
@@ -115,7 +115,7 @@ bool BaseInstrument::removeEvent( BaseAudioEvent* audioEvent, bool isLiveEvent )
 {
     bool removed = false;
 
-    if ( audioEvent == 0 )
+    if ( audioEvent == nullptr )
         return removed;
 
     if ( !isLiveEvent )
@@ -141,7 +141,7 @@ bool BaseInstrument::removeEvent( BaseAudioEvent* audioEvent, bool isLiveEvent )
         // otherwise we delete and dispose the events directly from this instrument
 
         delete audioEvent;
-        audioEvent = 0;
+        audioEvent = nullptr;
     }
 #endif
     return removed;

--- a/src/main/cpp/instruments/druminstrument.cpp
+++ b/src/main/cpp/instruments/druminstrument.cpp
@@ -39,6 +39,9 @@ DrumInstrument::~DrumInstrument()
 {
     delete rOsc;
     delete drumPatterns;
+
+    rOsc = nullptr;
+    drumPatterns = nullptr;
 }
 
 /* public methods */
@@ -59,7 +62,7 @@ void DrumInstrument::updateEvents()
 
 void DrumInstrument::clearEvents()
 {
-    if ( drumPatterns != 0 )
+    if ( drumPatterns != nullptr )
     {
         for ( int i = 0, l = drumPatterns->size(); i < l; ++i )
         {
@@ -77,7 +80,7 @@ bool DrumInstrument::removeEvent( BaseAudioEvent* audioEvent, bool isLiveEvent )
 {
     bool removed = false;
 
-    if ( audioEvent != 0 )
+    if ( audioEvent != nullptr )
     {
         if ( !isLiveEvent )
         {
@@ -98,7 +101,7 @@ bool DrumInstrument::removeEvent( BaseAudioEvent* audioEvent, bool isLiveEvent )
 
         if ( removed ) {
             delete audioEvent;
-            audioEvent = 0;
+            audioEvent = nullptr;
         }
     }
     return removed;
@@ -142,7 +145,7 @@ int DrumInstrument::setDrumPattern( DrumPattern* pattern )
 void DrumInstrument::construct()
 {
     drumTimbre        = DrumTimbres::LIGHT;
-    rOsc              = 0;// new RouteableOscillator();  // currently unused...
+    rOsc              = nullptr;// new RouteableOscillator();  // currently unused...
     audioChannel      = new AudioChannel( 1.0, AudioEngine::samples_per_bar );
 
     activeDrumPattern = 0;

--- a/src/main/cpp/instruments/oscillatorproperties.cpp
+++ b/src/main/cpp/instruments/oscillatorproperties.cpp
@@ -31,7 +31,7 @@ OscillatorProperties::OscillatorProperties( int aWaveform, float aDetune, int aO
     detune      = aDetune;
     octaveShift = aOctaveShift;
     fineShift   = aFineShift;
-    waveTable   = 0;
+    waveTable   = nullptr;
 
     setWaveform( aWaveform );
 }
@@ -39,6 +39,7 @@ OscillatorProperties::OscillatorProperties( int aWaveform, float aDetune, int aO
 OscillatorProperties::~OscillatorProperties()
 {
     delete waveTable;
+    waveTable = nullptr;
 }
 
 /* public methods */
@@ -50,24 +51,31 @@ int OscillatorProperties::getWaveform()
 
 void OscillatorProperties::setWaveform( int aWaveform )
 {
-    if ( waveTable != 0 )
-        delete waveTable;
+    if ( _waveform == aWaveform )
+        return;
 
     if ( aWaveform == WaveForms::TABLE ) {
-        // use setCustomWaveform instead
+        // use setCustomWaveform instead to provide a valid WaveTable
         return;
+    }
+    else {
+        // setting a waveform clears existing wave tables
+        if ( waveTable != nullptr ) {
+            delete waveTable;
+            waveTable = nullptr;
+        }
     }
     _waveform = aWaveform;
 }
 
 void OscillatorProperties::setCustomWaveform( std::string waveformId )
 {
-    if ( waveTable != 0 )
+    if ( waveTable != nullptr )
         delete waveTable;
 
     WaveTable* tableFromPool = TablePool::getTable( waveformId );
 
-    if ( tableFromPool != 0 )
+    if ( tableFromPool != nullptr )
         waveTable = tableFromPool->clone();
     else
         _waveform = WaveForms::SINE;

--- a/src/main/cpp/jni/javabridge.cpp
+++ b/src/main/cpp/jni/javabridge.cpp
@@ -23,8 +23,8 @@
 #include <jni/javabridge.h>
 #include <string.h>
 
-static JavaVM*  _vm    = 0;
-static jclass   _class = 0; // cached reference to Java mediator class
+static JavaVM*  _vm    = nullptr;
+static jclass   _class = nullptr; // cached reference to Java mediator class
 
 /**
  * called when the Java VM has finished
@@ -112,16 +112,16 @@ jclass JavaBridge::getJavaInterface()
 
     // might as well return as subsequent usage of
     // the interface requires a valid environment for it's invocation!
-    if ( environment == 0 )
-        return 0;
+    if ( environment == nullptr )
+        return nullptr;
 
     return _class; // we have a cached reference!
 }
 
 JNIEnv* JavaBridge::getEnvironment()
 {
-    if ( _vm == 0 )
-        return 0;
+    if ( _vm == nullptr )
+        return nullptr;
 
     JNIEnv *env;
     jint rs = _vm->AttachCurrentThread( &env, NULL );
@@ -133,7 +133,7 @@ JNIEnv* JavaBridge::getEnvironment()
     if ( rs == JNI_OK )
         return env;
     else
-        return 0;
+        return nullptr;
 }
 
 std::string JavaBridge::getString( jstring aString )

--- a/src/main/cpp/jni/javautilities.cpp
+++ b/src/main/cpp/jni/javautilities.cpp
@@ -40,7 +40,7 @@ bool JavaUtilities::createSampleFromFile( jstring aKey, jstring aWAVFilePath )
 
     // error during loading of WAV file ?
 
-    if ( WAV.buffer == 0 )
+    if ( WAV.buffer == nullptr )
         return false;
 
     SampleManager::setSample( JavaBridge::getString( aKey ), WAV.buffer, WAV.sampleRate );
@@ -116,7 +116,7 @@ bool JavaUtilities::createSampleFromAsset( jstring aKey, jobject assetManager, j
 
     // error during loading of WAV file ?
 
-    if ( WAV.buffer == 0 )
+    if ( WAV.buffer == nullptr )
         return false;
 
     SampleManager::setSample( JavaBridge::getString( aKey ), WAV.buffer, WAV.sampleRate );

--- a/src/main/cpp/modules/lfo.cpp
+++ b/src/main/cpp/modules/lfo.cpp
@@ -66,6 +66,7 @@ LFO::LFO()
 LFO::~LFO()
 {
     delete _table;
+    _table = nullptr;
 }
 
 /* public methods */
@@ -113,7 +114,7 @@ void LFO::generate()
 
     WaveTable* table = TablePool::getTable( SSTR( _wave ));
 
-    if ( table == 0 ) {
+    if ( table == nullptr ) {
         // no table in pool, LFO will generate table inline
         WaveGenerator::generate( _table, _wave );
     }

--- a/src/main/cpp/processors/delay.cpp
+++ b/src/main/cpp/processors/delay.cpp
@@ -55,6 +55,9 @@ Delay::~Delay()
 {
     delete _delayBuffer;
     delete[] _delayIndices;
+
+    _delayBuffer = nullptr;
+    _delayIndices = nullptr;
 }
 
 /* public methods */
@@ -116,7 +119,7 @@ void Delay::process( AudioBuffer* sampleBuffer, bool isMonoSource )
  */
 void Delay::reset()
 {
-    if ( _delayBuffer != 0 )
+    if ( _delayBuffer != nullptr )
         _delayBuffer->silenceBuffers();
 }
 

--- a/src/main/cpp/processors/filter.cpp
+++ b/src/main/cpp/processors/filter.cpp
@@ -60,6 +60,8 @@ Filter::~Filter()
     delete[] in2;
     delete[] out1;
     delete[] out2;
+
+    in1 = in2 = out1 = out2 = nullptr;
 }
 
 /* public methods */
@@ -168,7 +170,7 @@ void Filter::setLFO( LFO *lfo )
     _lfo = lfo;
 
     // no LFO ? make sure the filter returns to its default parameters
-    if ( lfo == 0 )
+    if ( lfo == nullptr )
     {
         _tempCutoff = _cutoff;
         calculateParameters();
@@ -180,7 +182,7 @@ void Filter::setLFO( LFO *lfo )
 
 bool Filter::hasLFO()
 {
-    return _lfo != 0;
+    return _lfo != nullptr;
 }
 
 /* private methods */
@@ -189,7 +191,7 @@ void Filter::init( float cutoff )
 {
     SAMPLE_RATE = ( float ) AudioEngineProps::SAMPLE_RATE;
 
-    _lfo        = 0;
+    _lfo        = nullptr;
     _cutoff     = _maxFreq;
     _tempCutoff = _cutoff;
 

--- a/src/main/cpp/processors/reverb.cpp
+++ b/src/main/cpp/processors/reverb.cpp
@@ -56,7 +56,7 @@ Reverb::~Reverb()
     if ( buf4 )
         delete[] buf4;
 
-    buf1 = buf2 = buf3 = buf4 = 0;
+    buf1 = buf2 = buf3 = buf4 = nullptr;
 }
 
 /* public methods */

--- a/src/main/cpp/ringbuffer.cpp
+++ b/src/main/cpp/ringbuffer.cpp
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2013-2016 Igor Zinken - http://www.igorski.nl
+ * Copyright (c) 2013-2018 Igor Zinken - http://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -36,6 +36,7 @@ RingBuffer::RingBuffer( int capacity )
 RingBuffer::~RingBuffer()
 {
     delete[] _buffer;
+    _buffer = nullptr;
 }
 
 /* public methods */

--- a/src/main/cpp/ringbuffer.h
+++ b/src/main/cpp/ringbuffer.h
@@ -66,7 +66,7 @@ class RingBuffer
 
             // set buffer values to 0.0 for silence
 
-            if ( _buffer != 0 )
+            if ( _buffer != nullptr )
                 memset( _buffer, 0, _bufferLength * sizeof( SAMPLE_TYPE ));
         }
 

--- a/src/main/cpp/tests/helpers/helper.cpp
+++ b/src/main/cpp/tests/helpers/helper.cpp
@@ -201,7 +201,7 @@ void deleteAudioEvent( BaseAudioEvent* audioEvent )
     BaseInstrument* instrument = audioEvent->getInstrument();
     delete audioEvent;
 
-    if ( instrument != 0 )
+    if ( instrument != nullptr )
         instrument->unregisterFromSequencer();
 
     delete instrument;

--- a/src/main/cpp/tests/utilities/samplemanager_test.cpp
+++ b/src/main/cpp/tests/utilities/samplemanager_test.cpp
@@ -72,7 +72,7 @@ TEST( SampleManager, RemoveSampleWithoutFree )
     ASSERT_FALSE( SampleManager::hasSample( id ))
         << "expected no Sample to be found as it has been removed";
 
-    ASSERT_FALSE( buffer == 0 ) << "expected AudioBuffer not to have been deleted";
+    ASSERT_FALSE( buffer == nullptr ) << "expected AudioBuffer not to have been deleted";
 
     delete buffer;
 }

--- a/src/main/cpp/tests/utilities/tablepool_test.cpp
+++ b/src/main/cpp/tests/utilities/tablepool_test.cpp
@@ -41,7 +41,7 @@ TEST( TablePool, RemoveTable )
 
     TablePool::removeTable( id, false );
 
-    ASSERT_FALSE( table == 0 ) << "expected Table not to have been deleted";
+    ASSERT_FALSE( table == nullptr ) << "expected Table not to have been deleted";
 
     delete table;
 }

--- a/src/main/cpp/utilities/diskwriter.cpp
+++ b/src/main/cpp/utilities/diskwriter.cpp
@@ -32,7 +32,7 @@ namespace DiskWriter
     std::string outputDirectory;
     unsigned long outputBufferSize  = 0;
     unsigned long outputWriterIndex = 0;
-    AudioBuffer*  cachedBuffer      = 0;
+    AudioBuffer*  cachedBuffer      = nullptr;
 
     /**
      * prepare a new iteration of recording
@@ -64,7 +64,7 @@ namespace DiskWriter
         int bufferSize    = aBuffer->bufferSize;
         int channelAmount = aBuffer->amountOfChannels;
 
-        if ( cachedBuffer == 0 )
+        if ( cachedBuffer == nullptr )
             generateOutputBuffer( channelAmount );
 
         cachedBuffer->mergeBuffers( aBuffer, 0, outputWriterIndex, 1.0 );
@@ -77,7 +77,7 @@ namespace DiskWriter
      */
     void appendBuffer( float* aBuffer, int aBufferSize, int amountOfChannels )
     {
-        if ( cachedBuffer == 0 )
+        if ( cachedBuffer == nullptr )
             generateOutputBuffer( amountOfChannels );
 
         int i, c, ci;
@@ -107,10 +107,10 @@ namespace DiskWriter
      */
     void flushOutput()
     {
-        if ( cachedBuffer != 0 )
+        if ( cachedBuffer != nullptr )
             delete cachedBuffer;
 
-        cachedBuffer      = 0;
+        cachedBuffer      = nullptr;
         outputWriterIndex = 0;
     }
 
@@ -123,7 +123,7 @@ namespace DiskWriter
     void writeBufferToFile( int aSampleRate, int aNumChannels, bool broadcastUpdate )
     {
         // quick assertion
-        if ( cachedBuffer == 0 )
+        if ( cachedBuffer == nullptr )
             return;
 
         // copy string contents for appending of filename

--- a/src/main/cpp/utilities/samplemanager.cpp
+++ b/src/main/cpp/utilities/samplemanager.cpp
@@ -40,7 +40,7 @@ void SampleManager::setSample( std::string aIdentifier, AudioBuffer* aBuffer, un
 AudioBuffer* SampleManager::getSample( std::string aIdentifier )
 {
     if ( !hasSample( aIdentifier ))
-        return 0;
+        return nullptr;
 
     std::map<std::string, cachedSample>::iterator it = SampleManagerSamples::_sampleMap.find( aIdentifier );
 

--- a/src/main/cpp/utilities/tablepool.cpp
+++ b/src/main/cpp/utilities/tablepool.cpp
@@ -33,7 +33,7 @@ WaveTable* TablePool::getTable( std::string tableId )
         // table existed, load the pooled version
         return ( WaveTable* )( it->second );
     }
-    return 0;
+    return nullptr;
 }
 
 bool TablePool::setTable( WaveTable* waveTable, std::string tableId )

--- a/src/main/cpp/utilities/wavereader.cpp
+++ b/src/main/cpp/utilities/wavereader.cpp
@@ -30,7 +30,7 @@
 waveFile WaveReader::fileToBuffer( std::string inputFile )
 { 
     FILE* fp;
-    AudioBuffer* buffer = 0;
+    AudioBuffer* buffer = nullptr;
     char id[ 5 ];
     unsigned int size;
     short* sound_buffer;
@@ -109,9 +109,9 @@ WaveTable* WaveReader::fileToTable( std::string inputFile )
 {
     waveFile WAV = fileToBuffer( inputFile );
 
-    if ( WAV.buffer == 0 ) {
+    if ( WAV.buffer == nullptr ) {
         Debug::log( "WaveReader::could not convert file '%s' to WaveTable", inputFile.c_str() );
-        return 0;
+        return nullptr;
     }
 
     WaveTable* out = new WaveTable( WAV.buffer->bufferSize, 440.0f );
@@ -132,7 +132,7 @@ waveFile WaveReader::byteArrayToBuffer( std::vector<char> byteArray )
 {
     // TODO: this mostly mirrors the fileToBuffer-method, clean this up!
 
-    AudioBuffer* buffer = 0;
+    AudioBuffer* buffer = nullptr;
 
     // first we'll check the necessary headers identifying the WAV file
 

--- a/src/main/cpp/wavetable.cpp
+++ b/src/main/cpp/wavetable.cpp
@@ -79,7 +79,7 @@ SAMPLE_TYPE* WaveTable::getBuffer()
 
 void WaveTable::setBuffer( SAMPLE_TYPE* aBuffer )
 {
-    if ( _buffer != 0 )
+    if ( _buffer != nullptr )
         delete[] _buffer;
 
     _buffer = aBuffer;


### PR DESCRIPTION
As pointed out (heh!) in https://github.com/igorski/MWEngine/issues/74
Needs careful testing, though lingering comparisons with _0_ rather than _nullptr_ should evaluate to the same end result and thus not cause engine instability, this is mostly here for semantic reasons.