### PR TITLE
Address "use of string after lifetime ends"-issue in debugger

### DIFF
--- a/mwengine/src/main/cpp/utilities/debug.cpp
+++ b/mwengine/src/main/cpp/utilities/debug.cpp
@@ -62,11 +62,11 @@ namespace Debug
 #ifdef DEBUG
         FILE* file = fopen( aFileName, "a" );
 
-        aMessage = ( std::string( aMessage ) + std::string( "\n" )).c_str();
+        auto formattedMessage = std::string( aMessage ) + std::string( "\n" );
 
         va_list args;
-        va_start( args, aMessage );
-        vfprintf( file, aMessage, args );
+        va_start( args, formattedMessage.c_str() );
+        vfprintf( file, formattedMessage.c_str(), args );
         va_end( args );
 
         fclose( file );


### PR DESCRIPTION
### Motivation

Calling c_str on a std::string object returns a pointer to the underlying character array. When the std::string object is destroyed, the pointer returned by c_str is no longer valid. If the pointer is used after the std::string object is destroyed, then the behavior is undefined.
